### PR TITLE
feat: expose api from client

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -13,7 +13,7 @@ In the [App.js](src/App.js#L5) replace the auth client (`const auth = new Client
 const supabaseURL = 'https://your-project-id.supabase.co'
 const supabaseAnon = 'your-anon-key'
 
-const auth = new Client({
+const auth = new GoTrueClient({
   url: `${supabaseURL}/auth/v1`,
   headers: {
     accept: 'json',

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -1421,14 +1421,14 @@
       "dependencies": {
         "@babel/code-frame": {
           "version": "7.10.4",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@babel/highlight": "^7.10.4"
           }
         },
         "@babel/core": {
           "version": "7.11.6",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@babel/code-frame": "^7.10.4",
             "@babel/generator": "^7.11.6",
@@ -1450,13 +1450,13 @@
           "dependencies": {
             "source-map": {
               "version": "0.5.7",
-              "bundled": true
+              "resolved": false
             }
           }
         },
         "@babel/generator": {
           "version": "7.11.6",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@babel/types": "^7.11.5",
             "jsesc": "^2.5.1",
@@ -1465,13 +1465,13 @@
           "dependencies": {
             "source-map": {
               "version": "0.5.7",
-              "bundled": true
+              "resolved": false
             }
           }
         },
         "@babel/helper-function-name": {
           "version": "7.10.4",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@babel/helper-get-function-arity": "^7.10.4",
             "@babel/template": "^7.10.4",
@@ -1480,28 +1480,28 @@
         },
         "@babel/helper-get-function-arity": {
           "version": "7.10.4",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@babel/types": "^7.10.4"
           }
         },
         "@babel/helper-member-expression-to-functions": {
           "version": "7.11.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@babel/types": "^7.11.0"
           }
         },
         "@babel/helper-module-imports": {
           "version": "7.10.4",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@babel/types": "^7.10.4"
           }
         },
         "@babel/helper-module-transforms": {
           "version": "7.11.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@babel/helper-module-imports": "^7.10.4",
             "@babel/helper-replace-supers": "^7.10.4",
@@ -1514,18 +1514,18 @@
         },
         "@babel/helper-optimise-call-expression": {
           "version": "7.10.4",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@babel/types": "^7.10.4"
           }
         },
         "@babel/helper-plugin-utils": {
           "version": "7.10.4",
-          "bundled": true
+          "resolved": false
         },
         "@babel/helper-replace-supers": {
           "version": "7.10.4",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@babel/helper-member-expression-to-functions": "^7.10.4",
             "@babel/helper-optimise-call-expression": "^7.10.4",
@@ -1535,7 +1535,7 @@
         },
         "@babel/helper-simple-access": {
           "version": "7.10.4",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@babel/template": "^7.10.4",
             "@babel/types": "^7.10.4"
@@ -1543,18 +1543,18 @@
         },
         "@babel/helper-split-export-declaration": {
           "version": "7.11.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@babel/types": "^7.11.0"
           }
         },
         "@babel/helper-validator-identifier": {
           "version": "7.10.4",
-          "bundled": true
+          "resolved": false
         },
         "@babel/helpers": {
           "version": "7.10.4",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@babel/template": "^7.10.4",
             "@babel/traverse": "^7.10.4",
@@ -1563,7 +1563,7 @@
         },
         "@babel/highlight": {
           "version": "7.10.4",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
             "chalk": "^2.0.0",
@@ -1572,14 +1572,14 @@
           "dependencies": {
             "ansi-styles": {
               "version": "3.2.1",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "color-convert": "^1.9.0"
               }
             },
             "chalk": {
               "version": "2.4.2",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "ansi-styles": "^3.2.1",
                 "escape-string-regexp": "^1.0.5",
@@ -1588,22 +1588,22 @@
             },
             "color-convert": {
               "version": "1.9.3",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "color-name": "1.1.3"
               }
             },
             "color-name": {
               "version": "1.1.3",
-              "bundled": true
+              "resolved": false
             },
             "has-flag": {
               "version": "3.0.0",
-              "bundled": true
+              "resolved": false
             },
             "supports-color": {
               "version": "5.5.0",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "has-flag": "^3.0.0"
               }
@@ -1612,88 +1612,88 @@
         },
         "@babel/parser": {
           "version": "7.11.5",
-          "bundled": true
+          "resolved": false
         },
         "@babel/plugin-syntax-async-generators": {
           "version": "7.8.4",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@babel/helper-plugin-utils": "^7.8.0"
           }
         },
         "@babel/plugin-syntax-bigint": {
           "version": "7.8.3",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@babel/helper-plugin-utils": "^7.8.0"
           }
         },
         "@babel/plugin-syntax-class-properties": {
           "version": "7.10.4",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@babel/helper-plugin-utils": "^7.10.4"
           }
         },
         "@babel/plugin-syntax-import-meta": {
           "version": "7.10.4",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@babel/helper-plugin-utils": "^7.10.4"
           }
         },
         "@babel/plugin-syntax-json-strings": {
           "version": "7.8.3",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@babel/helper-plugin-utils": "^7.8.0"
           }
         },
         "@babel/plugin-syntax-logical-assignment-operators": {
           "version": "7.10.4",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@babel/helper-plugin-utils": "^7.10.4"
           }
         },
         "@babel/plugin-syntax-nullish-coalescing-operator": {
           "version": "7.8.3",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@babel/helper-plugin-utils": "^7.8.0"
           }
         },
         "@babel/plugin-syntax-numeric-separator": {
           "version": "7.10.4",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@babel/helper-plugin-utils": "^7.10.4"
           }
         },
         "@babel/plugin-syntax-object-rest-spread": {
           "version": "7.8.3",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@babel/helper-plugin-utils": "^7.8.0"
           }
         },
         "@babel/plugin-syntax-optional-catch-binding": {
           "version": "7.8.3",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@babel/helper-plugin-utils": "^7.8.0"
           }
         },
         "@babel/plugin-syntax-optional-chaining": {
           "version": "7.8.3",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@babel/helper-plugin-utils": "^7.8.0"
           }
         },
         "@babel/template": {
           "version": "7.10.4",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@babel/code-frame": "^7.10.4",
             "@babel/parser": "^7.10.4",
@@ -1702,7 +1702,7 @@
         },
         "@babel/traverse": {
           "version": "7.11.5",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@babel/code-frame": "^7.10.4",
             "@babel/generator": "^7.11.5",
@@ -1717,7 +1717,7 @@
         },
         "@babel/types": {
           "version": "7.11.5",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
             "lodash": "^4.17.19",
@@ -1726,11 +1726,11 @@
         },
         "@bcoe/v8-coverage": {
           "version": "0.2.3",
-          "bundled": true
+          "resolved": false
         },
         "@cnakazawa/watch": {
           "version": "1.0.4",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "exec-sh": "^0.3.2",
             "minimist": "^1.2.0"
@@ -1738,7 +1738,7 @@
         },
         "@istanbuljs/load-nyc-config": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "camelcase": "^5.3.1",
             "find-up": "^4.1.0",
@@ -1749,11 +1749,11 @@
         },
         "@istanbuljs/schema": {
           "version": "0.1.2",
-          "bundled": true
+          "resolved": false
         },
         "@jest/console": {
           "version": "26.5.2",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@jest/types": "^26.5.2",
             "@types/node": "*",
@@ -1765,7 +1765,7 @@
           "dependencies": {
             "@jest/types": {
               "version": "26.5.2",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "@types/istanbul-lib-coverage": "^2.0.0",
                 "@types/istanbul-reports": "^3.0.0",
@@ -1776,14 +1776,14 @@
             },
             "@types/istanbul-reports": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "@types/istanbul-lib-report": "*"
               }
             },
             "chalk": {
               "version": "4.1.0",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "ansi-styles": "^4.1.0",
                 "supports-color": "^7.1.0"
@@ -1793,7 +1793,7 @@
         },
         "@jest/core": {
           "version": "26.5.3",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@jest/console": "^26.5.2",
             "@jest/reporters": "^26.5.3",
@@ -1827,7 +1827,7 @@
           "dependencies": {
             "@jest/types": {
               "version": "26.5.2",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "@types/istanbul-lib-coverage": "^2.0.0",
                 "@types/istanbul-reports": "^3.0.0",
@@ -1838,14 +1838,14 @@
             },
             "@types/istanbul-reports": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "@types/istanbul-lib-report": "*"
               }
             },
             "chalk": {
               "version": "4.1.0",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "ansi-styles": "^4.1.0",
                 "supports-color": "^7.1.0"
@@ -1855,7 +1855,7 @@
         },
         "@jest/environment": {
           "version": "26.5.2",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@jest/fake-timers": "^26.5.2",
             "@jest/types": "^26.5.2",
@@ -1865,7 +1865,7 @@
           "dependencies": {
             "@jest/types": {
               "version": "26.5.2",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "@types/istanbul-lib-coverage": "^2.0.0",
                 "@types/istanbul-reports": "^3.0.0",
@@ -1876,14 +1876,14 @@
             },
             "@types/istanbul-reports": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "@types/istanbul-lib-report": "*"
               }
             },
             "chalk": {
               "version": "4.1.0",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "ansi-styles": "^4.1.0",
                 "supports-color": "^7.1.0"
@@ -1893,7 +1893,7 @@
         },
         "@jest/fake-timers": {
           "version": "26.5.2",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@jest/types": "^26.5.2",
             "@sinonjs/fake-timers": "^6.0.1",
@@ -1905,7 +1905,7 @@
           "dependencies": {
             "@jest/types": {
               "version": "26.5.2",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "@types/istanbul-lib-coverage": "^2.0.0",
                 "@types/istanbul-reports": "^3.0.0",
@@ -1916,14 +1916,14 @@
             },
             "@types/istanbul-reports": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "@types/istanbul-lib-report": "*"
               }
             },
             "chalk": {
               "version": "4.1.0",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "ansi-styles": "^4.1.0",
                 "supports-color": "^7.1.0"
@@ -1933,7 +1933,7 @@
         },
         "@jest/globals": {
           "version": "26.5.3",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@jest/environment": "^26.5.2",
             "@jest/types": "^26.5.2",
@@ -1942,7 +1942,7 @@
           "dependencies": {
             "@jest/types": {
               "version": "26.5.2",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "@types/istanbul-lib-coverage": "^2.0.0",
                 "@types/istanbul-reports": "^3.0.0",
@@ -1953,14 +1953,14 @@
             },
             "@types/istanbul-reports": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "@types/istanbul-lib-report": "*"
               }
             },
             "chalk": {
               "version": "4.1.0",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "ansi-styles": "^4.1.0",
                 "supports-color": "^7.1.0"
@@ -1970,7 +1970,7 @@
         },
         "@jest/reporters": {
           "version": "26.5.3",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@bcoe/v8-coverage": "^0.2.3",
             "@jest/console": "^26.5.2",
@@ -2001,7 +2001,7 @@
           "dependencies": {
             "@jest/types": {
               "version": "26.5.2",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "@types/istanbul-lib-coverage": "^2.0.0",
                 "@types/istanbul-reports": "^3.0.0",
@@ -2012,14 +2012,14 @@
             },
             "@types/istanbul-reports": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "@types/istanbul-lib-report": "*"
               }
             },
             "chalk": {
               "version": "4.1.0",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "ansi-styles": "^4.1.0",
                 "supports-color": "^7.1.0"
@@ -2029,7 +2029,7 @@
         },
         "@jest/source-map": {
           "version": "26.5.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "callsites": "^3.0.0",
             "graceful-fs": "^4.2.4",
@@ -2038,7 +2038,7 @@
         },
         "@jest/test-result": {
           "version": "26.5.2",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@jest/console": "^26.5.2",
             "@jest/types": "^26.5.2",
@@ -2048,7 +2048,7 @@
           "dependencies": {
             "@jest/types": {
               "version": "26.5.2",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "@types/istanbul-lib-coverage": "^2.0.0",
                 "@types/istanbul-reports": "^3.0.0",
@@ -2059,14 +2059,14 @@
             },
             "@types/istanbul-reports": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "@types/istanbul-lib-report": "*"
               }
             },
             "chalk": {
               "version": "4.1.0",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "ansi-styles": "^4.1.0",
                 "supports-color": "^7.1.0"
@@ -2076,7 +2076,7 @@
         },
         "@jest/test-sequencer": {
           "version": "26.5.3",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@jest/test-result": "^26.5.2",
             "graceful-fs": "^4.2.4",
@@ -2087,7 +2087,7 @@
         },
         "@jest/transform": {
           "version": "26.5.2",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@babel/core": "^7.1.0",
             "@jest/types": "^26.5.2",
@@ -2108,7 +2108,7 @@
           "dependencies": {
             "@jest/types": {
               "version": "26.5.2",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "@types/istanbul-lib-coverage": "^2.0.0",
                 "@types/istanbul-reports": "^3.0.0",
@@ -2119,14 +2119,14 @@
             },
             "@types/istanbul-reports": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "@types/istanbul-lib-report": "*"
               }
             },
             "chalk": {
               "version": "4.1.0",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "ansi-styles": "^4.1.0",
                 "supports-color": "^7.1.0"
@@ -2136,7 +2136,7 @@
         },
         "@jest/types": {
           "version": "25.5.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
             "@types/istanbul-reports": "^1.1.1",
@@ -2146,21 +2146,21 @@
         },
         "@sinonjs/commons": {
           "version": "1.8.1",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "type-detect": "4.0.8"
           }
         },
         "@sinonjs/fake-timers": {
           "version": "6.0.1",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@sinonjs/commons": "^1.7.0"
           }
         },
         "@types/babel__core": {
           "version": "7.1.10",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@babel/parser": "^7.1.0",
             "@babel/types": "^7.0.0",
@@ -2171,14 +2171,14 @@
         },
         "@types/babel__generator": {
           "version": "7.6.2",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@babel/types": "^7.0.0"
           }
         },
         "@types/babel__template": {
           "version": "7.0.3",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@babel/parser": "^7.1.0",
             "@babel/types": "^7.0.0"
@@ -2186,32 +2186,32 @@
         },
         "@types/babel__traverse": {
           "version": "7.0.15",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@babel/types": "^7.3.0"
           }
         },
         "@types/graceful-fs": {
           "version": "4.1.3",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@types/node": "*"
           }
         },
         "@types/istanbul-lib-coverage": {
           "version": "2.0.3",
-          "bundled": true
+          "resolved": false
         },
         "@types/istanbul-lib-report": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@types/istanbul-lib-coverage": "*"
           }
         },
         "@types/istanbul-reports": {
           "version": "1.1.2",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@types/istanbul-lib-coverage": "*",
             "@types/istanbul-lib-report": "*"
@@ -2219,7 +2219,7 @@
         },
         "@types/jest": {
           "version": "26.0.14",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "jest-diff": "^25.2.1",
             "pretty-format": "^25.2.1"
@@ -2227,11 +2227,11 @@
         },
         "@types/node": {
           "version": "14.11.8",
-          "bundled": true
+          "resolved": false
         },
         "@types/node-fetch": {
           "version": "2.5.7",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@types/node": "*",
             "form-data": "^3.0.0"
@@ -2239,38 +2239,38 @@
         },
         "@types/normalize-package-data": {
           "version": "2.4.0",
-          "bundled": true
+          "resolved": false
         },
         "@types/prettier": {
           "version": "2.1.2",
-          "bundled": true
+          "resolved": false
         },
         "@types/stack-utils": {
           "version": "2.0.0",
-          "bundled": true
+          "resolved": false
         },
         "@types/yargs": {
           "version": "15.0.8",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@types/yargs-parser": "*"
           }
         },
         "@types/yargs-parser": {
           "version": "15.0.0",
-          "bundled": true
+          "resolved": false
         },
         "abab": {
           "version": "2.0.5",
-          "bundled": true
+          "resolved": false
         },
         "acorn": {
           "version": "7.4.1",
-          "bundled": true
+          "resolved": false
         },
         "acorn-globals": {
           "version": "6.0.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "acorn": "^7.1.1",
             "acorn-walk": "^7.1.1"
@@ -2278,11 +2278,11 @@
         },
         "acorn-walk": {
           "version": "7.2.0",
-          "bundled": true
+          "resolved": false
         },
         "ajv": {
           "version": "6.12.6",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "fast-json-stable-stringify": "^2.0.0",
@@ -2292,31 +2292,31 @@
         },
         "ansi-escapes": {
           "version": "4.3.1",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "type-fest": "^0.11.0"
           },
           "dependencies": {
             "type-fest": {
               "version": "0.11.0",
-              "bundled": true
+              "resolved": false
             }
           }
         },
         "ansi-regex": {
           "version": "5.0.0",
-          "bundled": true
+          "resolved": false
         },
         "ansi-styles": {
           "version": "4.3.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "color-convert": "^2.0.1"
           }
         },
         "anymatch": {
           "version": "3.1.1",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "normalize-path": "^3.0.0",
             "picomatch": "^2.0.4"
@@ -2324,65 +2324,65 @@
         },
         "argparse": {
           "version": "1.0.10",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "sprintf-js": "~1.0.2"
           }
         },
         "arr-diff": {
           "version": "4.0.0",
-          "bundled": true
+          "resolved": false
         },
         "arr-flatten": {
           "version": "1.1.0",
-          "bundled": true
+          "resolved": false
         },
         "arr-union": {
           "version": "3.1.0",
-          "bundled": true
+          "resolved": false
         },
         "array-unique": {
           "version": "0.3.2",
-          "bundled": true
+          "resolved": false
         },
         "asn1": {
           "version": "0.2.4",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "safer-buffer": "~2.1.0"
           }
         },
         "assert-plus": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": false
         },
         "assign-symbols": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": false
         },
         "asynckit": {
           "version": "0.4.0",
-          "bundled": true
+          "resolved": false
         },
         "at-least-node": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": false
         },
         "atob": {
           "version": "2.1.2",
-          "bundled": true
+          "resolved": false
         },
         "aws-sign2": {
           "version": "0.7.0",
-          "bundled": true
+          "resolved": false
         },
         "aws4": {
           "version": "1.10.1",
-          "bundled": true
+          "resolved": false
         },
         "babel-jest": {
           "version": "26.5.2",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@jest/transform": "^26.5.2",
             "@jest/types": "^26.5.2",
@@ -2396,7 +2396,7 @@
           "dependencies": {
             "@jest/types": {
               "version": "26.5.2",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "@types/istanbul-lib-coverage": "^2.0.0",
                 "@types/istanbul-reports": "^3.0.0",
@@ -2407,14 +2407,14 @@
             },
             "@types/istanbul-reports": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "@types/istanbul-lib-report": "*"
               }
             },
             "chalk": {
               "version": "4.1.0",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "ansi-styles": "^4.1.0",
                 "supports-color": "^7.1.0"
@@ -2424,7 +2424,7 @@
         },
         "babel-plugin-istanbul": {
           "version": "6.0.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@babel/helper-plugin-utils": "^7.0.0",
             "@istanbuljs/load-nyc-config": "^1.0.0",
@@ -2435,7 +2435,7 @@
         },
         "babel-plugin-jest-hoist": {
           "version": "26.5.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@babel/template": "^7.3.3",
             "@babel/types": "^7.3.3",
@@ -2445,7 +2445,7 @@
         },
         "babel-preset-current-node-syntax": {
           "version": "0.1.4",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@babel/plugin-syntax-async-generators": "^7.8.4",
             "@babel/plugin-syntax-bigint": "^7.8.3",
@@ -2462,7 +2462,7 @@
         },
         "babel-preset-jest": {
           "version": "26.5.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "babel-plugin-jest-hoist": "^26.5.0",
             "babel-preset-current-node-syntax": "^0.1.3"
@@ -2470,11 +2470,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": false
         },
         "base": {
           "version": "0.11.2",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "cache-base": "^1.0.1",
             "class-utils": "^0.3.5",
@@ -2487,28 +2487,28 @@
           "dependencies": {
             "define-property": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "is-descriptor": "^1.0.0"
               }
             },
             "is-accessor-descriptor": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "kind-of": "^6.0.0"
               }
             },
             "is-data-descriptor": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "kind-of": "^6.0.0"
               }
             },
             "is-descriptor": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "is-accessor-descriptor": "^1.0.0",
                 "is-data-descriptor": "^1.0.0",
@@ -2519,14 +2519,14 @@
         },
         "bcrypt-pbkdf": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "tweetnacl": "^0.14.3"
           }
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2534,36 +2534,36 @@
         },
         "braces": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "fill-range": "^7.0.1"
           }
         },
         "browser-process-hrtime": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": false
         },
         "bs-logger": {
           "version": "0.2.6",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "fast-json-stable-stringify": "2.x"
           }
         },
         "bser": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "node-int64": "^0.4.0"
           }
         },
         "buffer-from": {
           "version": "1.1.1",
-          "bundled": true
+          "resolved": false
         },
         "cache-base": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "collection-visit": "^1.0.0",
             "component-emitter": "^1.2.1",
@@ -2578,26 +2578,26 @@
         },
         "callsites": {
           "version": "3.1.0",
-          "bundled": true
+          "resolved": false
         },
         "camelcase": {
           "version": "5.3.1",
-          "bundled": true
+          "resolved": false
         },
         "capture-exit": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "rsvp": "^4.8.4"
           }
         },
         "caseless": {
           "version": "0.12.0",
-          "bundled": true
+          "resolved": false
         },
         "chalk": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
@@ -2605,15 +2605,15 @@
         },
         "char-regex": {
           "version": "1.0.2",
-          "bundled": true
+          "resolved": false
         },
         "ci-info": {
           "version": "2.0.0",
-          "bundled": true
+          "resolved": false
         },
         "class-utils": {
           "version": "0.3.6",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "arr-union": "^3.1.0",
             "define-property": "^0.2.5",
@@ -2623,7 +2623,7 @@
           "dependencies": {
             "define-property": {
               "version": "0.2.5",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "is-descriptor": "^0.1.0"
               }
@@ -2632,7 +2632,7 @@
         },
         "cliui": {
           "version": "6.0.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "string-width": "^4.2.0",
             "strip-ansi": "^6.0.0",
@@ -2641,15 +2641,15 @@
         },
         "co": {
           "version": "4.6.0",
-          "bundled": true
+          "resolved": false
         },
         "collect-v8-coverage": {
           "version": "1.0.1",
-          "bundled": true
+          "resolved": false
         },
         "collection-visit": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "map-visit": "^1.0.0",
             "object-visit": "^1.0.0"
@@ -2657,55 +2657,55 @@
         },
         "color-convert": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "color-name": "~1.1.4"
           }
         },
         "color-name": {
           "version": "1.1.4",
-          "bundled": true
+          "resolved": false
         },
         "combined-stream": {
           "version": "1.0.8",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "delayed-stream": "~1.0.0"
           }
         },
         "component-emitter": {
           "version": "1.3.0",
-          "bundled": true
+          "resolved": false
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "resolved": false
         },
         "convert-source-map": {
           "version": "1.7.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "safe-buffer": "~5.1.1"
           }
         },
         "copy-descriptor": {
           "version": "0.1.1",
-          "bundled": true
+          "resolved": false
         },
         "core-util-is": {
           "version": "1.0.2",
-          "bundled": true
+          "resolved": false
         },
         "cross-fetch": {
           "version": "3.0.6",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "node-fetch": "2.6.1"
           }
         },
         "cross-spawn": {
           "version": "6.0.5",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "nice-try": "^1.0.4",
             "path-key": "^2.0.1",
@@ -2716,31 +2716,31 @@
         },
         "cssom": {
           "version": "0.4.4",
-          "bundled": true
+          "resolved": false
         },
         "cssstyle": {
           "version": "2.3.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "cssom": "~0.3.6"
           },
           "dependencies": {
             "cssom": {
               "version": "0.3.8",
-              "bundled": true
+              "resolved": false
             }
           }
         },
         "dashdash": {
           "version": "1.14.1",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "assert-plus": "^1.0.0"
           }
         },
         "data-urls": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "abab": "^2.0.3",
             "whatwg-mimetype": "^2.3.0",
@@ -2749,41 +2749,41 @@
         },
         "debug": {
           "version": "4.2.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "ms": "2.1.2"
           }
         },
         "decamelize": {
           "version": "1.2.0",
-          "bundled": true
+          "resolved": false
         },
         "decimal.js": {
           "version": "10.2.1",
-          "bundled": true
+          "resolved": false
         },
         "decode-uri-component": {
           "version": "0.2.0",
-          "bundled": true
+          "resolved": false
         },
         "deep-is": {
           "version": "0.1.3",
-          "bundled": true
+          "resolved": false
         },
         "deepmerge": {
           "version": "4.2.2",
-          "bundled": true
+          "resolved": false
         },
         "define-properties": {
           "version": "1.1.3",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "object-keys": "^1.0.12"
           }
         },
         "define-property": {
           "version": "2.0.2",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "is-descriptor": "^1.0.2",
             "isobject": "^3.0.1"
@@ -2791,21 +2791,21 @@
           "dependencies": {
             "is-accessor-descriptor": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "kind-of": "^6.0.0"
               }
             },
             "is-data-descriptor": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "kind-of": "^6.0.0"
               }
             },
             "is-descriptor": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "is-accessor-descriptor": "^1.0.0",
                 "is-data-descriptor": "^1.0.0",
@@ -2816,32 +2816,32 @@
         },
         "delayed-stream": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": false
         },
         "detect-newline": {
           "version": "3.1.0",
-          "bundled": true
+          "resolved": false
         },
         "diff-sequences": {
           "version": "25.2.6",
-          "bundled": true
+          "resolved": false
         },
         "domexception": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "webidl-conversions": "^5.0.0"
           },
           "dependencies": {
             "webidl-conversions": {
               "version": "5.0.0",
-              "bundled": true
+              "resolved": false
             }
           }
         },
         "ecc-jsbn": {
           "version": "0.1.2",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "jsbn": "~0.1.0",
             "safer-buffer": "^2.1.0"
@@ -2849,29 +2849,29 @@
         },
         "emittery": {
           "version": "0.7.1",
-          "bundled": true
+          "resolved": false
         },
         "emoji-regex": {
           "version": "8.0.0",
-          "bundled": true
+          "resolved": false
         },
         "end-of-stream": {
           "version": "1.4.4",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "once": "^1.4.0"
           }
         },
         "error-ex": {
           "version": "1.3.2",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "is-arrayish": "^0.2.1"
           }
         },
         "es-abstract": {
           "version": "1.17.7",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "es-to-primitive": "^1.2.1",
             "function-bind": "^1.1.1",
@@ -2888,7 +2888,7 @@
         },
         "es-to-primitive": {
           "version": "1.2.1",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "is-callable": "^1.1.4",
             "is-date-object": "^1.0.1",
@@ -2897,11 +2897,11 @@
         },
         "escape-string-regexp": {
           "version": "1.0.5",
-          "bundled": true
+          "resolved": false
         },
         "escodegen": {
           "version": "1.14.3",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "esprima": "^4.0.1",
             "estraverse": "^4.2.0",
@@ -2912,23 +2912,23 @@
         },
         "esprima": {
           "version": "4.0.1",
-          "bundled": true
+          "resolved": false
         },
         "estraverse": {
           "version": "4.3.0",
-          "bundled": true
+          "resolved": false
         },
         "esutils": {
           "version": "2.0.3",
-          "bundled": true
+          "resolved": false
         },
         "exec-sh": {
           "version": "0.3.4",
-          "bundled": true
+          "resolved": false
         },
         "execa": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "cross-spawn": "^6.0.0",
             "get-stream": "^4.0.0",
@@ -2941,11 +2941,11 @@
         },
         "exit": {
           "version": "0.1.2",
-          "bundled": true
+          "resolved": false
         },
         "expand-brackets": {
           "version": "2.1.4",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "debug": "^2.3.3",
             "define-property": "^0.2.5",
@@ -2958,34 +2958,34 @@
           "dependencies": {
             "debug": {
               "version": "2.6.9",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "ms": "2.0.0"
               }
             },
             "define-property": {
               "version": "0.2.5",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "is-descriptor": "^0.1.0"
               }
             },
             "extend-shallow": {
               "version": "2.0.1",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "is-extendable": "^0.1.0"
               }
             },
             "ms": {
               "version": "2.0.0",
-              "bundled": true
+              "resolved": false
             }
           }
         },
         "expect": {
           "version": "26.5.3",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@jest/types": "^26.5.2",
             "ansi-styles": "^4.0.0",
@@ -2997,7 +2997,7 @@
           "dependencies": {
             "@jest/types": {
               "version": "26.5.2",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "@types/istanbul-lib-coverage": "^2.0.0",
                 "@types/istanbul-reports": "^3.0.0",
@@ -3008,14 +3008,14 @@
             },
             "@types/istanbul-reports": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "@types/istanbul-lib-report": "*"
               }
             },
             "chalk": {
               "version": "4.1.0",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "ansi-styles": "^4.1.0",
                 "supports-color": "^7.1.0"
@@ -3023,17 +3023,17 @@
             },
             "jest-get-type": {
               "version": "26.3.0",
-              "bundled": true
+              "resolved": false
             }
           }
         },
         "extend": {
           "version": "3.0.2",
-          "bundled": true
+          "resolved": false
         },
         "extend-shallow": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "assign-symbols": "^1.0.0",
             "is-extendable": "^1.0.1"
@@ -3041,7 +3041,7 @@
           "dependencies": {
             "is-extendable": {
               "version": "1.0.1",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "is-plain-object": "^2.0.4"
               }
@@ -3050,7 +3050,7 @@
         },
         "extglob": {
           "version": "2.0.4",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "array-unique": "^0.3.2",
             "define-property": "^1.0.0",
@@ -3064,35 +3064,35 @@
           "dependencies": {
             "define-property": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "is-descriptor": "^1.0.0"
               }
             },
             "extend-shallow": {
               "version": "2.0.1",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "is-extendable": "^0.1.0"
               }
             },
             "is-accessor-descriptor": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "kind-of": "^6.0.0"
               }
             },
             "is-data-descriptor": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "kind-of": "^6.0.0"
               }
             },
             "is-descriptor": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "is-accessor-descriptor": "^1.0.0",
                 "is-data-descriptor": "^1.0.0",
@@ -3103,37 +3103,37 @@
         },
         "extsprintf": {
           "version": "1.3.0",
-          "bundled": true
+          "resolved": false
         },
         "fast-deep-equal": {
           "version": "3.1.3",
-          "bundled": true
+          "resolved": false
         },
         "fast-json-stable-stringify": {
           "version": "2.1.0",
-          "bundled": true
+          "resolved": false
         },
         "fast-levenshtein": {
           "version": "2.0.6",
-          "bundled": true
+          "resolved": false
         },
         "fb-watchman": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "bser": "2.1.1"
           }
         },
         "fill-range": {
           "version": "7.0.1",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "to-regex-range": "^5.0.1"
           }
         },
         "find-up": {
           "version": "4.1.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "locate-path": "^5.0.0",
             "path-exists": "^4.0.0"
@@ -3141,15 +3141,15 @@
         },
         "for-in": {
           "version": "1.0.2",
-          "bundled": true
+          "resolved": false
         },
         "forever-agent": {
           "version": "0.6.1",
-          "bundled": true
+          "resolved": false
         },
         "form-data": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "asynckit": "^0.4.0",
             "combined-stream": "^1.0.8",
@@ -3158,14 +3158,14 @@
         },
         "fragment-cache": {
           "version": "0.2.1",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "map-cache": "^0.2.2"
           }
         },
         "fs-extra": {
           "version": "9.0.1",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "at-least-node": "^1.0.0",
             "graceful-fs": "^4.2.0",
@@ -3175,50 +3175,50 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": false
         },
         "fsevents": {
           "version": "2.1.3",
-          "bundled": true,
+          "resolved": false,
           "optional": true
         },
         "function-bind": {
           "version": "1.1.1",
-          "bundled": true
+          "resolved": false
         },
         "gensync": {
           "version": "1.0.0-beta.1",
-          "bundled": true
+          "resolved": false
         },
         "get-caller-file": {
           "version": "2.0.5",
-          "bundled": true
+          "resolved": false
         },
         "get-package-type": {
           "version": "0.1.0",
-          "bundled": true
+          "resolved": false
         },
         "get-stream": {
           "version": "4.1.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "pump": "^3.0.0"
           }
         },
         "get-value": {
           "version": "2.0.6",
-          "bundled": true
+          "resolved": false
         },
         "getpass": {
           "version": "0.1.7",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "assert-plus": "^1.0.0"
           }
         },
         "glob": {
           "version": "7.1.6",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
@@ -3230,20 +3230,20 @@
         },
         "globals": {
           "version": "11.12.0",
-          "bundled": true
+          "resolved": false
         },
         "graceful-fs": {
           "version": "4.2.4",
-          "bundled": true
+          "resolved": false
         },
         "growly": {
           "version": "1.3.0",
-          "bundled": true,
+          "resolved": false,
           "optional": true
         },
         "handlebars": {
           "version": "4.7.6",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "minimist": "^1.2.5",
             "neo-async": "^2.6.0",
@@ -3254,11 +3254,11 @@
         },
         "har-schema": {
           "version": "2.0.0",
-          "bundled": true
+          "resolved": false
         },
         "har-validator": {
           "version": "5.1.5",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "ajv": "^6.12.3",
             "har-schema": "^2.0.0"
@@ -3266,22 +3266,22 @@
         },
         "has": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "function-bind": "^1.1.1"
           }
         },
         "has-flag": {
           "version": "4.0.0",
-          "bundled": true
+          "resolved": false
         },
         "has-symbols": {
           "version": "1.0.1",
-          "bundled": true
+          "resolved": false
         },
         "has-value": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "get-value": "^2.0.6",
             "has-values": "^1.0.0",
@@ -3290,7 +3290,7 @@
         },
         "has-values": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "is-number": "^3.0.0",
             "kind-of": "^4.0.0"
@@ -3298,14 +3298,14 @@
           "dependencies": {
             "is-number": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "kind-of": "^3.0.2"
               },
               "dependencies": {
                 "kind-of": {
                   "version": "3.2.2",
-                  "bundled": true,
+                  "resolved": false,
                   "requires": {
                     "is-buffer": "^1.1.5"
                   }
@@ -3314,7 +3314,7 @@
             },
             "kind-of": {
               "version": "4.0.0",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "is-buffer": "^1.1.5"
               }
@@ -3323,26 +3323,26 @@
         },
         "highlight.js": {
           "version": "10.2.1",
-          "bundled": true
+          "resolved": false
         },
         "hosted-git-info": {
           "version": "2.8.8",
-          "bundled": true
+          "resolved": false
         },
         "html-encoding-sniffer": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "whatwg-encoding": "^1.0.5"
           }
         },
         "html-escaper": {
           "version": "2.0.2",
-          "bundled": true
+          "resolved": false
         },
         "http-signature": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "assert-plus": "^1.0.0",
             "jsprim": "^1.2.2",
@@ -3351,18 +3351,18 @@
         },
         "human-signals": {
           "version": "1.1.1",
-          "bundled": true
+          "resolved": false
         },
         "iconv-lite": {
           "version": "0.4.24",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "safer-buffer": ">= 2.1.2 < 3"
           }
         },
         "import-local": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "pkg-dir": "^4.2.0",
             "resolve-cwd": "^3.0.0"
@@ -3370,11 +3370,11 @@
         },
         "imurmurhash": {
           "version": "0.1.4",
-          "bundled": true
+          "resolved": false
         },
         "inflight": {
           "version": "1.0.6",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "once": "^1.3.0",
             "wrappy": "1"
@@ -3382,26 +3382,26 @@
         },
         "inherits": {
           "version": "2.0.4",
-          "bundled": true
+          "resolved": false
         },
         "interpret": {
           "version": "1.4.0",
-          "bundled": true
+          "resolved": false
         },
         "ip-regex": {
           "version": "2.1.0",
-          "bundled": true
+          "resolved": false
         },
         "is-accessor-descriptor": {
           "version": "0.1.6",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
               "version": "3.2.2",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "is-buffer": "^1.1.5"
               }
@@ -3410,33 +3410,33 @@
         },
         "is-arrayish": {
           "version": "0.2.1",
-          "bundled": true
+          "resolved": false
         },
         "is-buffer": {
           "version": "1.1.6",
-          "bundled": true
+          "resolved": false
         },
         "is-callable": {
           "version": "1.2.2",
-          "bundled": true
+          "resolved": false
         },
         "is-ci": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "ci-info": "^2.0.0"
           }
         },
         "is-data-descriptor": {
           "version": "0.1.4",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
               "version": "3.2.2",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "is-buffer": "^1.1.5"
               }
@@ -3445,11 +3445,11 @@
         },
         "is-date-object": {
           "version": "1.0.2",
-          "bundled": true
+          "resolved": false
         },
         "is-descriptor": {
           "version": "0.1.6",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "is-accessor-descriptor": "^0.1.6",
             "is-data-descriptor": "^0.1.4",
@@ -3458,75 +3458,75 @@
           "dependencies": {
             "kind-of": {
               "version": "5.1.0",
-              "bundled": true
+              "resolved": false
             }
           }
         },
         "is-docker": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": false,
           "optional": true
         },
         "is-extendable": {
           "version": "0.1.1",
-          "bundled": true
+          "resolved": false
         },
         "is-fullwidth-code-point": {
           "version": "3.0.0",
-          "bundled": true
+          "resolved": false
         },
         "is-generator-fn": {
           "version": "2.1.0",
-          "bundled": true
+          "resolved": false
         },
         "is-negative-zero": {
           "version": "2.0.0",
-          "bundled": true
+          "resolved": false
         },
         "is-number": {
           "version": "7.0.0",
-          "bundled": true
+          "resolved": false
         },
         "is-plain-object": {
           "version": "2.0.4",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "isobject": "^3.0.1"
           }
         },
         "is-potential-custom-element-name": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": false
         },
         "is-regex": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "has-symbols": "^1.0.1"
           }
         },
         "is-stream": {
           "version": "1.1.0",
-          "bundled": true
+          "resolved": false
         },
         "is-symbol": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "has-symbols": "^1.0.1"
           }
         },
         "is-typedarray": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": false
         },
         "is-windows": {
           "version": "1.0.2",
-          "bundled": true
+          "resolved": false
         },
         "is-wsl": {
           "version": "2.2.0",
-          "bundled": true,
+          "resolved": false,
           "optional": true,
           "requires": {
             "is-docker": "^2.0.0"
@@ -3534,27 +3534,27 @@
         },
         "isarray": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": false
         },
         "isexe": {
           "version": "2.0.0",
-          "bundled": true
+          "resolved": false
         },
         "isobject": {
           "version": "3.0.1",
-          "bundled": true
+          "resolved": false
         },
         "isstream": {
           "version": "0.1.2",
-          "bundled": true
+          "resolved": false
         },
         "istanbul-lib-coverage": {
           "version": "3.0.0",
-          "bundled": true
+          "resolved": false
         },
         "istanbul-lib-instrument": {
           "version": "4.0.3",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@babel/core": "^7.7.5",
             "@istanbuljs/schema": "^0.1.2",
@@ -3564,13 +3564,13 @@
           "dependencies": {
             "semver": {
               "version": "6.3.0",
-              "bundled": true
+              "resolved": false
             }
           }
         },
         "istanbul-lib-report": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "istanbul-lib-coverage": "^3.0.0",
             "make-dir": "^3.0.0",
@@ -3579,7 +3579,7 @@
         },
         "istanbul-lib-source-maps": {
           "version": "4.0.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "debug": "^4.1.1",
             "istanbul-lib-coverage": "^3.0.0",
@@ -3588,7 +3588,7 @@
         },
         "istanbul-reports": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "html-escaper": "^2.0.0",
             "istanbul-lib-report": "^3.0.0"
@@ -3596,7 +3596,7 @@
         },
         "jest": {
           "version": "26.5.3",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@jest/core": "^26.5.3",
             "import-local": "^3.0.2",
@@ -3605,7 +3605,7 @@
           "dependencies": {
             "@jest/types": {
               "version": "26.5.2",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "@types/istanbul-lib-coverage": "^2.0.0",
                 "@types/istanbul-reports": "^3.0.0",
@@ -3616,14 +3616,14 @@
             },
             "@types/istanbul-reports": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "@types/istanbul-lib-report": "*"
               }
             },
             "chalk": {
               "version": "4.1.0",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "ansi-styles": "^4.1.0",
                 "supports-color": "^7.1.0"
@@ -3631,7 +3631,7 @@
             },
             "jest-cli": {
               "version": "26.5.3",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "@jest/core": "^26.5.3",
                 "@jest/test-result": "^26.5.2",
@@ -3652,7 +3652,7 @@
         },
         "jest-changed-files": {
           "version": "26.5.2",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@jest/types": "^26.5.2",
             "execa": "^4.0.0",
@@ -3661,7 +3661,7 @@
           "dependencies": {
             "@jest/types": {
               "version": "26.5.2",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "@types/istanbul-lib-coverage": "^2.0.0",
                 "@types/istanbul-reports": "^3.0.0",
@@ -3672,14 +3672,14 @@
             },
             "@types/istanbul-reports": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "@types/istanbul-lib-report": "*"
               }
             },
             "chalk": {
               "version": "4.1.0",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "ansi-styles": "^4.1.0",
                 "supports-color": "^7.1.0"
@@ -3687,7 +3687,7 @@
             },
             "cross-spawn": {
               "version": "7.0.3",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "path-key": "^3.1.0",
                 "shebang-command": "^2.0.0",
@@ -3696,7 +3696,7 @@
             },
             "execa": {
               "version": "4.0.3",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "cross-spawn": "^7.0.0",
                 "get-stream": "^5.0.0",
@@ -3711,40 +3711,40 @@
             },
             "get-stream": {
               "version": "5.2.0",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "pump": "^3.0.0"
               }
             },
             "is-stream": {
               "version": "2.0.0",
-              "bundled": true
+              "resolved": false
             },
             "npm-run-path": {
               "version": "4.0.1",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "path-key": "^3.0.0"
               }
             },
             "path-key": {
               "version": "3.1.1",
-              "bundled": true
+              "resolved": false
             },
             "shebang-command": {
               "version": "2.0.0",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "shebang-regex": "^3.0.0"
               }
             },
             "shebang-regex": {
               "version": "3.0.0",
-              "bundled": true
+              "resolved": false
             },
             "which": {
               "version": "2.0.2",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "isexe": "^2.0.0"
               }
@@ -3753,7 +3753,7 @@
         },
         "jest-config": {
           "version": "26.5.3",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@babel/core": "^7.1.0",
             "@jest/test-sequencer": "^26.5.3",
@@ -3777,7 +3777,7 @@
           "dependencies": {
             "@jest/types": {
               "version": "26.5.2",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "@types/istanbul-lib-coverage": "^2.0.0",
                 "@types/istanbul-reports": "^3.0.0",
@@ -3788,14 +3788,14 @@
             },
             "@types/istanbul-reports": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "@types/istanbul-lib-report": "*"
               }
             },
             "chalk": {
               "version": "4.1.0",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "ansi-styles": "^4.1.0",
                 "supports-color": "^7.1.0"
@@ -3803,11 +3803,11 @@
             },
             "jest-get-type": {
               "version": "26.3.0",
-              "bundled": true
+              "resolved": false
             },
             "pretty-format": {
               "version": "26.5.2",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "@jest/types": "^26.5.2",
                 "ansi-regex": "^5.0.0",
@@ -3819,7 +3819,7 @@
         },
         "jest-diff": {
           "version": "25.5.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "chalk": "^3.0.0",
             "diff-sequences": "^25.2.6",
@@ -3829,14 +3829,14 @@
         },
         "jest-docblock": {
           "version": "26.0.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "detect-newline": "^3.0.0"
           }
         },
         "jest-each": {
           "version": "26.5.2",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@jest/types": "^26.5.2",
             "chalk": "^4.0.0",
@@ -3847,7 +3847,7 @@
           "dependencies": {
             "@jest/types": {
               "version": "26.5.2",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "@types/istanbul-lib-coverage": "^2.0.0",
                 "@types/istanbul-reports": "^3.0.0",
@@ -3858,14 +3858,14 @@
             },
             "@types/istanbul-reports": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "@types/istanbul-lib-report": "*"
               }
             },
             "chalk": {
               "version": "4.1.0",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "ansi-styles": "^4.1.0",
                 "supports-color": "^7.1.0"
@@ -3873,11 +3873,11 @@
             },
             "jest-get-type": {
               "version": "26.3.0",
-              "bundled": true
+              "resolved": false
             },
             "pretty-format": {
               "version": "26.5.2",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "@jest/types": "^26.5.2",
                 "ansi-regex": "^5.0.0",
@@ -3889,7 +3889,7 @@
         },
         "jest-environment-jsdom": {
           "version": "26.5.2",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@jest/environment": "^26.5.2",
             "@jest/fake-timers": "^26.5.2",
@@ -3902,7 +3902,7 @@
           "dependencies": {
             "@jest/types": {
               "version": "26.5.2",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "@types/istanbul-lib-coverage": "^2.0.0",
                 "@types/istanbul-reports": "^3.0.0",
@@ -3913,14 +3913,14 @@
             },
             "@types/istanbul-reports": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "@types/istanbul-lib-report": "*"
               }
             },
             "chalk": {
               "version": "4.1.0",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "ansi-styles": "^4.1.0",
                 "supports-color": "^7.1.0"
@@ -3930,7 +3930,7 @@
         },
         "jest-environment-node": {
           "version": "26.5.2",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@jest/environment": "^26.5.2",
             "@jest/fake-timers": "^26.5.2",
@@ -3942,7 +3942,7 @@
           "dependencies": {
             "@jest/types": {
               "version": "26.5.2",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "@types/istanbul-lib-coverage": "^2.0.0",
                 "@types/istanbul-reports": "^3.0.0",
@@ -3953,14 +3953,14 @@
             },
             "@types/istanbul-reports": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "@types/istanbul-lib-report": "*"
               }
             },
             "chalk": {
               "version": "4.1.0",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "ansi-styles": "^4.1.0",
                 "supports-color": "^7.1.0"
@@ -3970,11 +3970,11 @@
         },
         "jest-get-type": {
           "version": "25.2.6",
-          "bundled": true
+          "resolved": false
         },
         "jest-haste-map": {
           "version": "26.5.2",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@jest/types": "^26.5.2",
             "@types/graceful-fs": "^4.1.2",
@@ -3994,7 +3994,7 @@
           "dependencies": {
             "@jest/types": {
               "version": "26.5.2",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "@types/istanbul-lib-coverage": "^2.0.0",
                 "@types/istanbul-reports": "^3.0.0",
@@ -4005,14 +4005,14 @@
             },
             "@types/istanbul-reports": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "@types/istanbul-lib-report": "*"
               }
             },
             "chalk": {
               "version": "4.1.0",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "ansi-styles": "^4.1.0",
                 "supports-color": "^7.1.0"
@@ -4022,7 +4022,7 @@
         },
         "jest-jasmine2": {
           "version": "26.5.3",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@babel/traverse": "^7.1.0",
             "@jest/environment": "^26.5.2",
@@ -4046,7 +4046,7 @@
           "dependencies": {
             "@jest/types": {
               "version": "26.5.2",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "@types/istanbul-lib-coverage": "^2.0.0",
                 "@types/istanbul-reports": "^3.0.0",
@@ -4057,14 +4057,14 @@
             },
             "@types/istanbul-reports": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "@types/istanbul-lib-report": "*"
               }
             },
             "chalk": {
               "version": "4.1.0",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "ansi-styles": "^4.1.0",
                 "supports-color": "^7.1.0"
@@ -4072,7 +4072,7 @@
             },
             "pretty-format": {
               "version": "26.5.2",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "@jest/types": "^26.5.2",
                 "ansi-regex": "^5.0.0",
@@ -4084,7 +4084,7 @@
         },
         "jest-leak-detector": {
           "version": "26.5.2",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "jest-get-type": "^26.3.0",
             "pretty-format": "^26.5.2"
@@ -4092,7 +4092,7 @@
           "dependencies": {
             "@jest/types": {
               "version": "26.5.2",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "@types/istanbul-lib-coverage": "^2.0.0",
                 "@types/istanbul-reports": "^3.0.0",
@@ -4103,14 +4103,14 @@
             },
             "@types/istanbul-reports": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "@types/istanbul-lib-report": "*"
               }
             },
             "chalk": {
               "version": "4.1.0",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "ansi-styles": "^4.1.0",
                 "supports-color": "^7.1.0"
@@ -4118,11 +4118,11 @@
             },
             "jest-get-type": {
               "version": "26.3.0",
-              "bundled": true
+              "resolved": false
             },
             "pretty-format": {
               "version": "26.5.2",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "@jest/types": "^26.5.2",
                 "ansi-regex": "^5.0.0",
@@ -4134,7 +4134,7 @@
         },
         "jest-matcher-utils": {
           "version": "26.5.2",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "chalk": "^4.0.0",
             "jest-diff": "^26.5.2",
@@ -4144,7 +4144,7 @@
           "dependencies": {
             "@jest/types": {
               "version": "26.5.2",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "@types/istanbul-lib-coverage": "^2.0.0",
                 "@types/istanbul-reports": "^3.0.0",
@@ -4155,14 +4155,14 @@
             },
             "@types/istanbul-reports": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "@types/istanbul-lib-report": "*"
               }
             },
             "chalk": {
               "version": "4.1.0",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "ansi-styles": "^4.1.0",
                 "supports-color": "^7.1.0"
@@ -4170,11 +4170,11 @@
             },
             "diff-sequences": {
               "version": "26.5.0",
-              "bundled": true
+              "resolved": false
             },
             "jest-diff": {
               "version": "26.5.2",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "chalk": "^4.0.0",
                 "diff-sequences": "^26.5.0",
@@ -4184,11 +4184,11 @@
             },
             "jest-get-type": {
               "version": "26.3.0",
-              "bundled": true
+              "resolved": false
             },
             "pretty-format": {
               "version": "26.5.2",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "@jest/types": "^26.5.2",
                 "ansi-regex": "^5.0.0",
@@ -4200,7 +4200,7 @@
         },
         "jest-message-util": {
           "version": "26.5.2",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@babel/code-frame": "^7.0.0",
             "@jest/types": "^26.5.2",
@@ -4214,7 +4214,7 @@
           "dependencies": {
             "@jest/types": {
               "version": "26.5.2",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "@types/istanbul-lib-coverage": "^2.0.0",
                 "@types/istanbul-reports": "^3.0.0",
@@ -4225,14 +4225,14 @@
             },
             "@types/istanbul-reports": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "@types/istanbul-lib-report": "*"
               }
             },
             "chalk": {
               "version": "4.1.0",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "ansi-styles": "^4.1.0",
                 "supports-color": "^7.1.0"
@@ -4242,7 +4242,7 @@
         },
         "jest-mock": {
           "version": "26.5.2",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@jest/types": "^26.5.2",
             "@types/node": "*"
@@ -4250,7 +4250,7 @@
           "dependencies": {
             "@jest/types": {
               "version": "26.5.2",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "@types/istanbul-lib-coverage": "^2.0.0",
                 "@types/istanbul-reports": "^3.0.0",
@@ -4261,14 +4261,14 @@
             },
             "@types/istanbul-reports": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "@types/istanbul-lib-report": "*"
               }
             },
             "chalk": {
               "version": "4.1.0",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "ansi-styles": "^4.1.0",
                 "supports-color": "^7.1.0"
@@ -4278,15 +4278,15 @@
         },
         "jest-pnp-resolver": {
           "version": "1.2.2",
-          "bundled": true
+          "resolved": false
         },
         "jest-regex-util": {
           "version": "26.0.0",
-          "bundled": true
+          "resolved": false
         },
         "jest-resolve": {
           "version": "26.5.2",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@jest/types": "^26.5.2",
             "chalk": "^4.0.0",
@@ -4300,7 +4300,7 @@
           "dependencies": {
             "@jest/types": {
               "version": "26.5.2",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "@types/istanbul-lib-coverage": "^2.0.0",
                 "@types/istanbul-reports": "^3.0.0",
@@ -4311,14 +4311,14 @@
             },
             "@types/istanbul-reports": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "@types/istanbul-lib-report": "*"
               }
             },
             "chalk": {
               "version": "4.1.0",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "ansi-styles": "^4.1.0",
                 "supports-color": "^7.1.0"
@@ -4328,7 +4328,7 @@
         },
         "jest-resolve-dependencies": {
           "version": "26.5.3",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@jest/types": "^26.5.2",
             "jest-regex-util": "^26.0.0",
@@ -4337,7 +4337,7 @@
           "dependencies": {
             "@jest/types": {
               "version": "26.5.2",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "@types/istanbul-lib-coverage": "^2.0.0",
                 "@types/istanbul-reports": "^3.0.0",
@@ -4348,14 +4348,14 @@
             },
             "@types/istanbul-reports": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "@types/istanbul-lib-report": "*"
               }
             },
             "chalk": {
               "version": "4.1.0",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "ansi-styles": "^4.1.0",
                 "supports-color": "^7.1.0"
@@ -4365,7 +4365,7 @@
         },
         "jest-runner": {
           "version": "26.5.3",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@jest/console": "^26.5.2",
             "@jest/environment": "^26.5.2",
@@ -4391,7 +4391,7 @@
           "dependencies": {
             "@jest/types": {
               "version": "26.5.2",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "@types/istanbul-lib-coverage": "^2.0.0",
                 "@types/istanbul-reports": "^3.0.0",
@@ -4402,14 +4402,14 @@
             },
             "@types/istanbul-reports": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "@types/istanbul-lib-report": "*"
               }
             },
             "chalk": {
               "version": "4.1.0",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "ansi-styles": "^4.1.0",
                 "supports-color": "^7.1.0"
@@ -4419,7 +4419,7 @@
         },
         "jest-runtime": {
           "version": "26.5.3",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@jest/console": "^26.5.2",
             "@jest/environment": "^26.5.2",
@@ -4451,7 +4451,7 @@
           "dependencies": {
             "@jest/types": {
               "version": "26.5.2",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "@types/istanbul-lib-coverage": "^2.0.0",
                 "@types/istanbul-reports": "^3.0.0",
@@ -4462,14 +4462,14 @@
             },
             "@types/istanbul-reports": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "@types/istanbul-lib-report": "*"
               }
             },
             "chalk": {
               "version": "4.1.0",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "ansi-styles": "^4.1.0",
                 "supports-color": "^7.1.0"
@@ -4479,7 +4479,7 @@
         },
         "jest-serializer": {
           "version": "26.5.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@types/node": "*",
             "graceful-fs": "^4.2.4"
@@ -4487,7 +4487,7 @@
         },
         "jest-snapshot": {
           "version": "26.5.3",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@babel/types": "^7.0.0",
             "@jest/types": "^26.5.2",
@@ -4509,7 +4509,7 @@
           "dependencies": {
             "@jest/types": {
               "version": "26.5.2",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "@types/istanbul-lib-coverage": "^2.0.0",
                 "@types/istanbul-reports": "^3.0.0",
@@ -4520,14 +4520,14 @@
             },
             "@types/istanbul-reports": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "@types/istanbul-lib-report": "*"
               }
             },
             "chalk": {
               "version": "4.1.0",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "ansi-styles": "^4.1.0",
                 "supports-color": "^7.1.0"
@@ -4535,11 +4535,11 @@
             },
             "diff-sequences": {
               "version": "26.5.0",
-              "bundled": true
+              "resolved": false
             },
             "jest-diff": {
               "version": "26.5.2",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "chalk": "^4.0.0",
                 "diff-sequences": "^26.5.0",
@@ -4549,11 +4549,11 @@
             },
             "jest-get-type": {
               "version": "26.3.0",
-              "bundled": true
+              "resolved": false
             },
             "pretty-format": {
               "version": "26.5.2",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "@jest/types": "^26.5.2",
                 "ansi-regex": "^5.0.0",
@@ -4563,13 +4563,13 @@
             },
             "semver": {
               "version": "7.3.2",
-              "bundled": true
+              "resolved": false
             }
           }
         },
         "jest-util": {
           "version": "26.5.2",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@jest/types": "^26.5.2",
             "@types/node": "*",
@@ -4581,7 +4581,7 @@
           "dependencies": {
             "@jest/types": {
               "version": "26.5.2",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "@types/istanbul-lib-coverage": "^2.0.0",
                 "@types/istanbul-reports": "^3.0.0",
@@ -4592,14 +4592,14 @@
             },
             "@types/istanbul-reports": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "@types/istanbul-lib-report": "*"
               }
             },
             "chalk": {
               "version": "4.1.0",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "ansi-styles": "^4.1.0",
                 "supports-color": "^7.1.0"
@@ -4609,7 +4609,7 @@
         },
         "jest-validate": {
           "version": "26.5.3",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@jest/types": "^26.5.2",
             "camelcase": "^6.0.0",
@@ -4621,7 +4621,7 @@
           "dependencies": {
             "@jest/types": {
               "version": "26.5.2",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "@types/istanbul-lib-coverage": "^2.0.0",
                 "@types/istanbul-reports": "^3.0.0",
@@ -4632,18 +4632,18 @@
             },
             "@types/istanbul-reports": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "@types/istanbul-lib-report": "*"
               }
             },
             "camelcase": {
               "version": "6.1.0",
-              "bundled": true
+              "resolved": false
             },
             "chalk": {
               "version": "4.1.0",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "ansi-styles": "^4.1.0",
                 "supports-color": "^7.1.0"
@@ -4651,11 +4651,11 @@
             },
             "jest-get-type": {
               "version": "26.3.0",
-              "bundled": true
+              "resolved": false
             },
             "pretty-format": {
               "version": "26.5.2",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "@jest/types": "^26.5.2",
                 "ansi-regex": "^5.0.0",
@@ -4667,7 +4667,7 @@
         },
         "jest-watcher": {
           "version": "26.5.2",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@jest/test-result": "^26.5.2",
             "@jest/types": "^26.5.2",
@@ -4680,7 +4680,7 @@
           "dependencies": {
             "@jest/types": {
               "version": "26.5.2",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "@types/istanbul-lib-coverage": "^2.0.0",
                 "@types/istanbul-reports": "^3.0.0",
@@ -4691,14 +4691,14 @@
             },
             "@types/istanbul-reports": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "@types/istanbul-lib-report": "*"
               }
             },
             "chalk": {
               "version": "4.1.0",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "ansi-styles": "^4.1.0",
                 "supports-color": "^7.1.0"
@@ -4708,7 +4708,7 @@
         },
         "jest-worker": {
           "version": "26.5.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@types/node": "*",
             "merge-stream": "^2.0.0",
@@ -4717,11 +4717,11 @@
         },
         "js-tokens": {
           "version": "4.0.0",
-          "bundled": true
+          "resolved": false
         },
         "js-yaml": {
           "version": "3.14.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "argparse": "^1.0.7",
             "esprima": "^4.0.0"
@@ -4729,11 +4729,11 @@
         },
         "jsbn": {
           "version": "0.1.1",
-          "bundled": true
+          "resolved": false
         },
         "jsdom": {
           "version": "16.4.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "abab": "^2.0.3",
             "acorn": "^7.1.1",
@@ -4765,38 +4765,38 @@
         },
         "jsesc": {
           "version": "2.5.2",
-          "bundled": true
+          "resolved": false
         },
         "json-parse-better-errors": {
           "version": "1.0.2",
-          "bundled": true
+          "resolved": false
         },
         "json-parse-even-better-errors": {
           "version": "2.3.1",
-          "bundled": true
+          "resolved": false
         },
         "json-schema": {
           "version": "0.2.3",
-          "bundled": true
+          "resolved": false
         },
         "json-schema-traverse": {
           "version": "0.4.1",
-          "bundled": true
+          "resolved": false
         },
         "json-stringify-safe": {
           "version": "5.0.1",
-          "bundled": true
+          "resolved": false
         },
         "json5": {
           "version": "2.1.3",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "minimist": "^1.2.5"
           }
         },
         "jsonfile": {
           "version": "6.0.1",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "graceful-fs": "^4.1.6",
             "universalify": "^1.0.0"
@@ -4804,7 +4804,7 @@
         },
         "jsprim": {
           "version": "1.4.1",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "assert-plus": "1.0.0",
             "extsprintf": "1.3.0",
@@ -4814,19 +4814,19 @@
         },
         "kind-of": {
           "version": "6.0.3",
-          "bundled": true
+          "resolved": false
         },
         "kleur": {
           "version": "3.0.3",
-          "bundled": true
+          "resolved": false
         },
         "leven": {
           "version": "3.1.0",
-          "bundled": true
+          "resolved": false
         },
         "levn": {
           "version": "0.3.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "prelude-ls": "~1.1.2",
             "type-check": "~0.3.2"
@@ -4834,11 +4834,11 @@
         },
         "lines-and-columns": {
           "version": "1.1.6",
-          "bundled": true
+          "resolved": false
         },
         "load-json-file": {
           "version": "4.0.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "graceful-fs": "^4.1.2",
             "parse-json": "^4.0.0",
@@ -4848,7 +4848,7 @@
           "dependencies": {
             "parse-json": {
               "version": "4.0.0",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "error-ex": "^1.3.1",
                 "json-parse-better-errors": "^1.0.1"
@@ -4856,83 +4856,83 @@
             },
             "strip-bom": {
               "version": "3.0.0",
-              "bundled": true
+              "resolved": false
             }
           }
         },
         "locate-path": {
           "version": "5.0.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "p-locate": "^4.1.0"
           }
         },
         "lodash": {
           "version": "4.17.20",
-          "bundled": true
+          "resolved": false
         },
         "lodash.memoize": {
           "version": "4.1.2",
-          "bundled": true
+          "resolved": false
         },
         "lodash.sortby": {
           "version": "4.7.0",
-          "bundled": true
+          "resolved": false
         },
         "lunr": {
           "version": "2.3.9",
-          "bundled": true
+          "resolved": false
         },
         "make-dir": {
           "version": "3.1.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "semver": "^6.0.0"
           },
           "dependencies": {
             "semver": {
               "version": "6.3.0",
-              "bundled": true
+              "resolved": false
             }
           }
         },
         "make-error": {
           "version": "1.3.6",
-          "bundled": true
+          "resolved": false
         },
         "makeerror": {
           "version": "1.0.11",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "tmpl": "1.0.x"
           }
         },
         "map-cache": {
           "version": "0.2.2",
-          "bundled": true
+          "resolved": false
         },
         "map-visit": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "object-visit": "^1.0.0"
           }
         },
         "marked": {
           "version": "1.2.0",
-          "bundled": true
+          "resolved": false
         },
         "memorystream": {
           "version": "0.3.1",
-          "bundled": true
+          "resolved": false
         },
         "merge-stream": {
           "version": "2.0.0",
-          "bundled": true
+          "resolved": false
         },
         "micromatch": {
           "version": "4.0.2",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "braces": "^3.0.1",
             "picomatch": "^2.0.5"
@@ -4940,33 +4940,33 @@
         },
         "mime-db": {
           "version": "1.44.0",
-          "bundled": true
+          "resolved": false
         },
         "mime-types": {
           "version": "2.1.27",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "mime-db": "1.44.0"
           }
         },
         "mimic-fn": {
           "version": "2.1.0",
-          "bundled": true
+          "resolved": false
         },
         "minimatch": {
           "version": "3.0.4",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "1.2.5",
-          "bundled": true
+          "resolved": false
         },
         "mixin-deep": {
           "version": "1.3.2",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "for-in": "^1.0.2",
             "is-extendable": "^1.0.1"
@@ -4974,7 +4974,7 @@
           "dependencies": {
             "is-extendable": {
               "version": "1.0.1",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "is-plain-object": "^2.0.4"
               }
@@ -4983,15 +4983,15 @@
         },
         "mkdirp": {
           "version": "1.0.4",
-          "bundled": true
+          "resolved": false
         },
         "ms": {
           "version": "2.1.2",
-          "bundled": true
+          "resolved": false
         },
         "nanomatch": {
           "version": "1.2.13",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "arr-diff": "^4.0.0",
             "array-unique": "^0.3.2",
@@ -5008,31 +5008,31 @@
         },
         "natural-compare": {
           "version": "1.4.0",
-          "bundled": true
+          "resolved": false
         },
         "neo-async": {
           "version": "2.6.2",
-          "bundled": true
+          "resolved": false
         },
         "nice-try": {
           "version": "1.0.5",
-          "bundled": true
+          "resolved": false
         },
         "node-fetch": {
           "version": "2.6.1",
-          "bundled": true
+          "resolved": false
         },
         "node-int64": {
           "version": "0.4.0",
-          "bundled": true
+          "resolved": false
         },
         "node-modules-regexp": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": false
         },
         "node-notifier": {
           "version": "8.0.0",
-          "bundled": true,
+          "resolved": false,
           "optional": true,
           "requires": {
             "growly": "^1.3.0",
@@ -5045,12 +5045,12 @@
           "dependencies": {
             "semver": {
               "version": "7.3.2",
-              "bundled": true,
+              "resolved": false,
               "optional": true
             },
             "which": {
               "version": "2.0.2",
-              "bundled": true,
+              "resolved": false,
               "optional": true,
               "requires": {
                 "isexe": "^2.0.0"
@@ -5060,7 +5060,7 @@
         },
         "normalize-package-data": {
           "version": "2.5.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "hosted-git-info": "^2.1.4",
             "resolve": "^1.10.0",
@@ -5070,11 +5070,11 @@
         },
         "normalize-path": {
           "version": "3.0.0",
-          "bundled": true
+          "resolved": false
         },
         "npm-run-all": {
           "version": "4.1.5",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "ansi-styles": "^3.2.1",
             "chalk": "^2.4.1",
@@ -5089,14 +5089,14 @@
           "dependencies": {
             "ansi-styles": {
               "version": "3.2.1",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "color-convert": "^1.9.0"
               }
             },
             "chalk": {
               "version": "2.4.2",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "ansi-styles": "^3.2.1",
                 "escape-string-regexp": "^1.0.5",
@@ -5105,22 +5105,22 @@
             },
             "color-convert": {
               "version": "1.9.3",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "color-name": "1.1.3"
               }
             },
             "color-name": {
               "version": "1.1.3",
-              "bundled": true
+              "resolved": false
             },
             "has-flag": {
               "version": "3.0.0",
-              "bundled": true
+              "resolved": false
             },
             "read-pkg": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "load-json-file": "^4.0.0",
                 "normalize-package-data": "^2.3.2",
@@ -5129,7 +5129,7 @@
             },
             "supports-color": {
               "version": "5.5.0",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "has-flag": "^3.0.0"
               }
@@ -5138,22 +5138,22 @@
         },
         "npm-run-path": {
           "version": "2.0.2",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "path-key": "^2.0.0"
           }
         },
         "nwsapi": {
           "version": "2.2.0",
-          "bundled": true
+          "resolved": false
         },
         "oauth-sign": {
           "version": "0.9.0",
-          "bundled": true
+          "resolved": false
         },
         "object-copy": {
           "version": "0.1.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "copy-descriptor": "^0.1.0",
             "define-property": "^0.2.5",
@@ -5162,14 +5162,14 @@
           "dependencies": {
             "define-property": {
               "version": "0.2.5",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "is-descriptor": "^0.1.0"
               }
             },
             "kind-of": {
               "version": "3.2.2",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "is-buffer": "^1.1.5"
               }
@@ -5178,22 +5178,22 @@
         },
         "object-inspect": {
           "version": "1.8.0",
-          "bundled": true
+          "resolved": false
         },
         "object-keys": {
           "version": "1.1.1",
-          "bundled": true
+          "resolved": false
         },
         "object-visit": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "isobject": "^3.0.0"
           }
         },
         "object.assign": {
           "version": "4.1.1",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "define-properties": "^1.1.3",
             "es-abstract": "^1.18.0-next.0",
@@ -5203,7 +5203,7 @@
           "dependencies": {
             "es-abstract": {
               "version": "1.18.0-next.1",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "es-to-primitive": "^1.2.1",
                 "function-bind": "^1.1.1",
@@ -5223,28 +5223,28 @@
         },
         "object.pick": {
           "version": "1.3.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "isobject": "^3.0.1"
           }
         },
         "once": {
           "version": "1.4.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "wrappy": "1"
           }
         },
         "onetime": {
           "version": "5.1.2",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "mimic-fn": "^2.1.0"
           }
         },
         "optionator": {
           "version": "0.8.3",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "deep-is": "~0.1.3",
             "fast-levenshtein": "~2.0.6",
@@ -5256,33 +5256,33 @@
         },
         "p-each-series": {
           "version": "2.1.0",
-          "bundled": true
+          "resolved": false
         },
         "p-finally": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": false
         },
         "p-limit": {
           "version": "2.3.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "p-try": "^2.0.0"
           }
         },
         "p-locate": {
           "version": "4.1.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "p-limit": "^2.2.0"
           }
         },
         "p-try": {
           "version": "2.2.0",
-          "bundled": true
+          "resolved": false
         },
         "parse-json": {
           "version": "5.1.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@babel/code-frame": "^7.0.0",
             "error-ex": "^1.3.1",
@@ -5292,80 +5292,80 @@
         },
         "parse5": {
           "version": "5.1.1",
-          "bundled": true
+          "resolved": false
         },
         "pascalcase": {
           "version": "0.1.1",
-          "bundled": true
+          "resolved": false
         },
         "path-exists": {
           "version": "4.0.0",
-          "bundled": true
+          "resolved": false
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "bundled": true
+          "resolved": false
         },
         "path-key": {
           "version": "2.0.1",
-          "bundled": true
+          "resolved": false
         },
         "path-parse": {
           "version": "1.0.6",
-          "bundled": true
+          "resolved": false
         },
         "path-type": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "pify": "^3.0.0"
           }
         },
         "performance-now": {
           "version": "2.1.0",
-          "bundled": true
+          "resolved": false
         },
         "picomatch": {
           "version": "2.2.2",
-          "bundled": true
+          "resolved": false
         },
         "pidtree": {
           "version": "0.3.1",
-          "bundled": true
+          "resolved": false
         },
         "pify": {
           "version": "3.0.0",
-          "bundled": true
+          "resolved": false
         },
         "pirates": {
           "version": "4.0.1",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "node-modules-regexp": "^1.0.0"
           }
         },
         "pkg-dir": {
           "version": "4.2.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "find-up": "^4.0.0"
           }
         },
         "posix-character-classes": {
           "version": "0.1.1",
-          "bundled": true
+          "resolved": false
         },
         "prelude-ls": {
           "version": "1.1.2",
-          "bundled": true
+          "resolved": false
         },
         "prettier": {
           "version": "2.1.2",
-          "bundled": true
+          "resolved": false
         },
         "pretty-format": {
           "version": "25.5.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@jest/types": "^25.5.0",
             "ansi-regex": "^5.0.0",
@@ -5375,11 +5375,11 @@
         },
         "progress": {
           "version": "2.0.3",
-          "bundled": true
+          "resolved": false
         },
         "prompts": {
           "version": "2.3.2",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "kleur": "^3.0.3",
             "sisteransi": "^1.0.4"
@@ -5387,11 +5387,11 @@
         },
         "psl": {
           "version": "1.8.0",
-          "bundled": true
+          "resolved": false
         },
         "pump": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "end-of-stream": "^1.1.0",
             "once": "^1.3.1"
@@ -5399,19 +5399,19 @@
         },
         "punycode": {
           "version": "2.1.1",
-          "bundled": true
+          "resolved": false
         },
         "qs": {
           "version": "6.5.2",
-          "bundled": true
+          "resolved": false
         },
         "react-is": {
           "version": "16.13.1",
-          "bundled": true
+          "resolved": false
         },
         "read-pkg": {
           "version": "5.2.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@types/normalize-package-data": "^2.4.0",
             "normalize-package-data": "^2.5.0",
@@ -5421,13 +5421,13 @@
           "dependencies": {
             "type-fest": {
               "version": "0.6.0",
-              "bundled": true
+              "resolved": false
             }
           }
         },
         "read-pkg-up": {
           "version": "7.0.1",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "find-up": "^4.1.0",
             "read-pkg": "^5.2.0",
@@ -5436,14 +5436,14 @@
         },
         "rechoir": {
           "version": "0.6.2",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "resolve": "^1.1.6"
           }
         },
         "regex-not": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "extend-shallow": "^3.0.2",
             "safe-regex": "^1.1.0"
@@ -5451,19 +5451,19 @@
         },
         "remove-trailing-separator": {
           "version": "1.1.0",
-          "bundled": true
+          "resolved": false
         },
         "repeat-element": {
           "version": "1.1.3",
-          "bundled": true
+          "resolved": false
         },
         "repeat-string": {
           "version": "1.6.1",
-          "bundled": true
+          "resolved": false
         },
         "request": {
           "version": "2.88.2",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "aws-sign2": "~0.7.0",
             "aws4": "^1.8.0",
@@ -5489,7 +5489,7 @@
           "dependencies": {
             "form-data": {
               "version": "2.3.3",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.6",
@@ -5498,7 +5498,7 @@
             },
             "tough-cookie": {
               "version": "2.5.0",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "psl": "^1.1.28",
                 "punycode": "^2.1.1"
@@ -5506,20 +5506,20 @@
             },
             "uuid": {
               "version": "3.4.0",
-              "bundled": true
+              "resolved": false
             }
           }
         },
         "request-promise-core": {
           "version": "1.1.4",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "lodash": "^4.17.19"
           }
         },
         "request-promise-native": {
           "version": "1.0.9",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "request-promise-core": "1.1.4",
             "stealthy-require": "^1.1.1",
@@ -5528,7 +5528,7 @@
           "dependencies": {
             "tough-cookie": {
               "version": "2.5.0",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "psl": "^1.1.28",
                 "punycode": "^2.1.1"
@@ -5538,67 +5538,67 @@
         },
         "require-directory": {
           "version": "2.1.1",
-          "bundled": true
+          "resolved": false
         },
         "require-main-filename": {
           "version": "2.0.0",
-          "bundled": true
+          "resolved": false
         },
         "resolve": {
           "version": "1.17.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "path-parse": "^1.0.6"
           }
         },
         "resolve-cwd": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "resolve-from": "^5.0.0"
           }
         },
         "resolve-from": {
           "version": "5.0.0",
-          "bundled": true
+          "resolved": false
         },
         "resolve-url": {
           "version": "0.2.1",
-          "bundled": true
+          "resolved": false
         },
         "ret": {
           "version": "0.1.15",
-          "bundled": true
+          "resolved": false
         },
         "rimraf": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "glob": "^7.1.3"
           }
         },
         "rsvp": {
           "version": "4.8.5",
-          "bundled": true
+          "resolved": false
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "resolved": false
         },
         "safe-regex": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "ret": "~0.1.10"
           }
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "bundled": true
+          "resolved": false
         },
         "sane": {
           "version": "4.1.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@cnakazawa/watch": "^1.0.3",
             "anymatch": "^2.0.0",
@@ -5613,7 +5613,7 @@
           "dependencies": {
             "anymatch": {
               "version": "2.0.0",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "micromatch": "^3.1.4",
                 "normalize-path": "^2.1.1"
@@ -5621,7 +5621,7 @@
             },
             "braces": {
               "version": "2.3.2",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "arr-flatten": "^1.1.0",
                 "array-unique": "^0.3.2",
@@ -5637,7 +5637,7 @@
               "dependencies": {
                 "extend-shallow": {
                   "version": "2.0.1",
-                  "bundled": true,
+                  "resolved": false,
                   "requires": {
                     "is-extendable": "^0.1.0"
                   }
@@ -5646,7 +5646,7 @@
             },
             "fill-range": {
               "version": "4.0.0",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "extend-shallow": "^2.0.1",
                 "is-number": "^3.0.0",
@@ -5656,7 +5656,7 @@
               "dependencies": {
                 "extend-shallow": {
                   "version": "2.0.1",
-                  "bundled": true,
+                  "resolved": false,
                   "requires": {
                     "is-extendable": "^0.1.0"
                   }
@@ -5665,14 +5665,14 @@
             },
             "is-number": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "kind-of": "^3.0.2"
               },
               "dependencies": {
                 "kind-of": {
                   "version": "3.2.2",
-                  "bundled": true,
+                  "resolved": false,
                   "requires": {
                     "is-buffer": "^1.1.5"
                   }
@@ -5681,7 +5681,7 @@
             },
             "micromatch": {
               "version": "3.1.10",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "arr-diff": "^4.0.0",
                 "array-unique": "^0.3.2",
@@ -5700,14 +5700,14 @@
             },
             "normalize-path": {
               "version": "2.1.1",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "remove-trailing-separator": "^1.0.1"
               }
             },
             "to-regex-range": {
               "version": "2.1.1",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "is-number": "^3.0.0",
                 "repeat-string": "^1.6.1"
@@ -5717,22 +5717,22 @@
         },
         "saxes": {
           "version": "5.0.1",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "xmlchars": "^2.2.0"
           }
         },
         "semver": {
           "version": "5.7.1",
-          "bundled": true
+          "resolved": false
         },
         "set-blocking": {
           "version": "2.0.0",
-          "bundled": true
+          "resolved": false
         },
         "set-value": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "extend-shallow": "^2.0.1",
             "is-extendable": "^0.1.1",
@@ -5742,7 +5742,7 @@
           "dependencies": {
             "extend-shallow": {
               "version": "2.0.1",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "is-extendable": "^0.1.0"
               }
@@ -5751,22 +5751,22 @@
         },
         "shebang-command": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "shebang-regex": "^1.0.0"
           }
         },
         "shebang-regex": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": false
         },
         "shell-quote": {
           "version": "1.7.2",
-          "bundled": true
+          "resolved": false
         },
         "shelljs": {
           "version": "0.8.4",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "glob": "^7.0.0",
             "interpret": "^1.0.0",
@@ -5775,24 +5775,24 @@
         },
         "shellwords": {
           "version": "0.1.1",
-          "bundled": true,
+          "resolved": false,
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.3",
-          "bundled": true
+          "resolved": false
         },
         "sisteransi": {
           "version": "1.0.5",
-          "bundled": true
+          "resolved": false
         },
         "slash": {
           "version": "3.0.0",
-          "bundled": true
+          "resolved": false
         },
         "snapdragon": {
           "version": "0.8.2",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "base": "^0.11.1",
             "debug": "^2.2.0",
@@ -5806,38 +5806,38 @@
           "dependencies": {
             "debug": {
               "version": "2.6.9",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "ms": "2.0.0"
               }
             },
             "define-property": {
               "version": "0.2.5",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "is-descriptor": "^0.1.0"
               }
             },
             "extend-shallow": {
               "version": "2.0.1",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "is-extendable": "^0.1.0"
               }
             },
             "ms": {
               "version": "2.0.0",
-              "bundled": true
+              "resolved": false
             },
             "source-map": {
               "version": "0.5.7",
-              "bundled": true
+              "resolved": false
             }
           }
         },
         "snapdragon-node": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "define-property": "^1.0.0",
             "isobject": "^3.0.0",
@@ -5846,28 +5846,28 @@
           "dependencies": {
             "define-property": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "is-descriptor": "^1.0.0"
               }
             },
             "is-accessor-descriptor": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "kind-of": "^6.0.0"
               }
             },
             "is-data-descriptor": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "kind-of": "^6.0.0"
               }
             },
             "is-descriptor": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "is-accessor-descriptor": "^1.0.0",
                 "is-data-descriptor": "^1.0.0",
@@ -5878,14 +5878,14 @@
         },
         "snapdragon-util": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "kind-of": "^3.2.0"
           },
           "dependencies": {
             "kind-of": {
               "version": "3.2.2",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "is-buffer": "^1.1.5"
               }
@@ -5894,11 +5894,11 @@
         },
         "source-map": {
           "version": "0.6.1",
-          "bundled": true
+          "resolved": false
         },
         "source-map-resolve": {
           "version": "0.5.3",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "atob": "^2.1.2",
             "decode-uri-component": "^0.2.0",
@@ -5909,7 +5909,7 @@
         },
         "source-map-support": {
           "version": "0.5.19",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "buffer-from": "^1.0.0",
             "source-map": "^0.6.0"
@@ -5917,11 +5917,11 @@
         },
         "source-map-url": {
           "version": "0.4.0",
-          "bundled": true
+          "resolved": false
         },
         "spdx-correct": {
           "version": "3.1.1",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "spdx-expression-parse": "^3.0.0",
             "spdx-license-ids": "^3.0.0"
@@ -5929,11 +5929,11 @@
         },
         "spdx-exceptions": {
           "version": "2.3.0",
-          "bundled": true
+          "resolved": false
         },
         "spdx-expression-parse": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "spdx-exceptions": "^2.1.0",
             "spdx-license-ids": "^3.0.0"
@@ -5941,22 +5941,22 @@
         },
         "spdx-license-ids": {
           "version": "3.0.6",
-          "bundled": true
+          "resolved": false
         },
         "split-string": {
           "version": "3.1.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "extend-shallow": "^3.0.0"
           }
         },
         "sprintf-js": {
           "version": "1.0.3",
-          "bundled": true
+          "resolved": false
         },
         "sshpk": {
           "version": "1.16.1",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "asn1": "~0.2.3",
             "assert-plus": "^1.0.0",
@@ -5971,20 +5971,20 @@
         },
         "stack-utils": {
           "version": "2.0.2",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "escape-string-regexp": "^2.0.0"
           },
           "dependencies": {
             "escape-string-regexp": {
               "version": "2.0.0",
-              "bundled": true
+              "resolved": false
             }
           }
         },
         "static-extend": {
           "version": "0.1.2",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "define-property": "^0.2.5",
             "object-copy": "^0.1.0"
@@ -5992,7 +5992,7 @@
           "dependencies": {
             "define-property": {
               "version": "0.2.5",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "is-descriptor": "^0.1.0"
               }
@@ -6001,11 +6001,11 @@
         },
         "stealthy-require": {
           "version": "1.1.1",
-          "bundled": true
+          "resolved": false
         },
         "string-length": {
           "version": "4.0.1",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "char-regex": "^1.0.2",
             "strip-ansi": "^6.0.0"
@@ -6013,7 +6013,7 @@
         },
         "string-width": {
           "version": "4.2.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "emoji-regex": "^8.0.0",
             "is-fullwidth-code-point": "^3.0.0",
@@ -6022,7 +6022,7 @@
         },
         "string.prototype.padend": {
           "version": "3.1.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "define-properties": "^1.1.3",
             "es-abstract": "^1.17.0-next.1"
@@ -6030,7 +6030,7 @@
         },
         "string.prototype.trimend": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "define-properties": "^1.1.3",
             "es-abstract": "^1.17.5"
@@ -6038,7 +6038,7 @@
         },
         "string.prototype.trimstart": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "define-properties": "^1.1.3",
             "es-abstract": "^1.17.5"
@@ -6046,33 +6046,33 @@
         },
         "strip-ansi": {
           "version": "6.0.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "ansi-regex": "^5.0.0"
           }
         },
         "strip-bom": {
           "version": "4.0.0",
-          "bundled": true
+          "resolved": false
         },
         "strip-eof": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": false
         },
         "strip-final-newline": {
           "version": "2.0.0",
-          "bundled": true
+          "resolved": false
         },
         "supports-color": {
           "version": "7.2.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "has-flag": "^4.0.0"
           }
         },
         "supports-hyperlinks": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "has-flag": "^4.0.0",
             "supports-color": "^7.0.0"
@@ -6080,11 +6080,11 @@
         },
         "symbol-tree": {
           "version": "3.2.4",
-          "bundled": true
+          "resolved": false
         },
         "terminal-link": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "ansi-escapes": "^4.2.1",
             "supports-hyperlinks": "^2.0.0"
@@ -6092,7 +6092,7 @@
         },
         "test-exclude": {
           "version": "6.0.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@istanbuljs/schema": "^0.1.2",
             "glob": "^7.1.4",
@@ -6101,26 +6101,26 @@
         },
         "throat": {
           "version": "5.0.0",
-          "bundled": true
+          "resolved": false
         },
         "tmpl": {
           "version": "1.0.4",
-          "bundled": true
+          "resolved": false
         },
         "to-fast-properties": {
           "version": "2.0.0",
-          "bundled": true
+          "resolved": false
         },
         "to-object-path": {
           "version": "0.3.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
               "version": "3.2.2",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "is-buffer": "^1.1.5"
               }
@@ -6129,7 +6129,7 @@
         },
         "to-regex": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "define-property": "^2.0.2",
             "extend-shallow": "^3.0.2",
@@ -6139,14 +6139,14 @@
         },
         "to-regex-range": {
           "version": "5.0.1",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "is-number": "^7.0.0"
           }
         },
         "tough-cookie": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "ip-regex": "^2.1.0",
             "psl": "^1.1.28",
@@ -6155,14 +6155,14 @@
         },
         "tr46": {
           "version": "2.0.2",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "punycode": "^2.1.1"
           }
         },
         "ts-jest": {
           "version": "26.4.1",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@types/jest": "26.x",
             "bs-logger": "0.x",
@@ -6179,50 +6179,50 @@
           "dependencies": {
             "semver": {
               "version": "7.3.2",
-              "bundled": true
+              "resolved": false
             },
             "yargs-parser": {
               "version": "20.2.1",
-              "bundled": true
+              "resolved": false
             }
           }
         },
         "tunnel-agent": {
           "version": "0.6.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "safe-buffer": "^5.0.1"
           }
         },
         "tweetnacl": {
           "version": "0.14.5",
-          "bundled": true
+          "resolved": false
         },
         "type-check": {
           "version": "0.3.2",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "prelude-ls": "~1.1.2"
           }
         },
         "type-detect": {
           "version": "4.0.8",
-          "bundled": true
+          "resolved": false
         },
         "type-fest": {
           "version": "0.8.1",
-          "bundled": true
+          "resolved": false
         },
         "typedarray-to-buffer": {
           "version": "3.1.5",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "is-typedarray": "^1.0.0"
           }
         },
         "typedoc": {
           "version": "0.19.2",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "fs-extra": "^9.0.1",
             "handlebars": "^4.7.6",
@@ -6239,26 +6239,26 @@
           "dependencies": {
             "semver": {
               "version": "7.3.2",
-              "bundled": true
+              "resolved": false
             }
           }
         },
         "typedoc-default-themes": {
           "version": "0.11.4",
-          "bundled": true
+          "resolved": false
         },
         "typescript": {
           "version": "4.0.3",
-          "bundled": true
+          "resolved": false
         },
         "uglify-js": {
           "version": "3.11.2",
-          "bundled": true,
+          "resolved": false,
           "optional": true
         },
         "union-value": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "arr-union": "^3.1.0",
             "get-value": "^2.0.6",
@@ -6268,11 +6268,11 @@
         },
         "universalify": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": false
         },
         "unset-value": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "has-value": "^0.3.1",
             "isobject": "^3.0.0"
@@ -6280,7 +6280,7 @@
           "dependencies": {
             "has-value": {
               "version": "0.3.1",
-              "bundled": true,
+              "resolved": false,
               "requires": {
                 "get-value": "^2.0.3",
                 "has-values": "^0.1.4",
@@ -6289,7 +6289,7 @@
               "dependencies": {
                 "isobject": {
                   "version": "2.1.0",
-                  "bundled": true,
+                  "resolved": false,
                   "requires": {
                     "isarray": "1.0.0"
                   }
@@ -6298,33 +6298,33 @@
             },
             "has-values": {
               "version": "0.1.4",
-              "bundled": true
+              "resolved": false
             }
           }
         },
         "uri-js": {
           "version": "4.4.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "punycode": "^2.1.0"
           }
         },
         "urix": {
           "version": "0.1.0",
-          "bundled": true
+          "resolved": false
         },
         "use": {
           "version": "3.1.1",
-          "bundled": true
+          "resolved": false
         },
         "uuid": {
           "version": "8.3.1",
-          "bundled": true,
+          "resolved": false,
           "optional": true
         },
         "v8-to-istanbul": {
           "version": "6.0.1",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.1",
             "convert-source-map": "^1.6.0",
@@ -6333,13 +6333,13 @@
           "dependencies": {
             "source-map": {
               "version": "0.7.3",
-              "bundled": true
+              "resolved": false
             }
           }
         },
         "validate-npm-package-license": {
           "version": "3.0.4",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "spdx-correct": "^3.0.0",
             "spdx-expression-parse": "^3.0.0"
@@ -6347,7 +6347,7 @@
         },
         "verror": {
           "version": "1.10.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "assert-plus": "^1.0.0",
             "core-util-is": "1.0.2",
@@ -6356,43 +6356,43 @@
         },
         "w3c-hr-time": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "browser-process-hrtime": "^1.0.0"
           }
         },
         "w3c-xmlserializer": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "xml-name-validator": "^3.0.0"
           }
         },
         "walker": {
           "version": "1.0.7",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "makeerror": "1.0.x"
           }
         },
         "webidl-conversions": {
           "version": "6.1.0",
-          "bundled": true
+          "resolved": false
         },
         "whatwg-encoding": {
           "version": "1.0.5",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "iconv-lite": "0.4.24"
           }
         },
         "whatwg-mimetype": {
           "version": "2.3.0",
-          "bundled": true
+          "resolved": false
         },
         "whatwg-url": {
           "version": "8.4.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "lodash.sortby": "^4.7.0",
             "tr46": "^2.0.2",
@@ -6401,26 +6401,26 @@
         },
         "which": {
           "version": "1.3.1",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "isexe": "^2.0.0"
           }
         },
         "which-module": {
           "version": "2.0.0",
-          "bundled": true
+          "resolved": false
         },
         "word-wrap": {
           "version": "1.2.3",
-          "bundled": true
+          "resolved": false
         },
         "wordwrap": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": false
         },
         "wrap-ansi": {
           "version": "6.2.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "ansi-styles": "^4.0.0",
             "string-width": "^4.1.0",
@@ -6429,11 +6429,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "resolved": false
         },
         "write-file-atomic": {
           "version": "3.0.3",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "imurmurhash": "^0.1.4",
             "is-typedarray": "^1.0.0",
@@ -6443,23 +6443,23 @@
         },
         "ws": {
           "version": "7.3.1",
-          "bundled": true
+          "resolved": false
         },
         "xml-name-validator": {
           "version": "3.0.0",
-          "bundled": true
+          "resolved": false
         },
         "xmlchars": {
           "version": "2.2.0",
-          "bundled": true
+          "resolved": false
         },
         "y18n": {
           "version": "4.0.0",
-          "bundled": true
+          "resolved": false
         },
         "yargs": {
           "version": "15.4.1",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "cliui": "^6.0.0",
             "decamelize": "^1.2.0",
@@ -6476,7 +6476,7 @@
         },
         "yargs-parser": {
           "version": "18.1.3",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "camelcase": "^5.0.0",
             "decamelize": "^1.2.0"

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -21,9 +21,9 @@ function App() {
   }
   async function handleEmailSignIn() {
     if (rememberMe) {
-      localStorage.setItem('email', email);
+      localStorage.setItem('email', email)
     } else {
-      localStorage.removeItem('email');
+      localStorage.removeItem('email')
     }
     let { error } = await auth.signIn({ email, password })
     if (error) console.log('Error: ', error.message)
@@ -37,15 +37,15 @@ function App() {
     if (error) console.log('Error: ', error.message)
   }
   async function forgotPassword() {
-    var email = prompt("Please enter your email:");
-    if (email === null || email === "") {
+    var email = prompt('Please enter your email:')
+    if (email === null || email === '') {
       window.alert('You must enter your email.')
     } else {
-      let { data, error } =  auth.api.resetPasswordForEmail(email);
+      let { error } = await auth.api.resetPasswordForEmail(email)
       if (error) {
         console.log('Error: ', error.message)
       } else {
-        alert(data)
+        alert('Password recovery email has been sent.')
       }
     }
   }
@@ -113,7 +113,7 @@ function App() {
               <input
                 id="remember_me"
                 type="checkbox"
-                onChange={() => setRememberMe(! rememberMe)}
+                onChange={() => setRememberMe(!rememberMe)}
                 className="form-checkbox h-4 w-4 text-indigo-600 transition duration-150 ease-in-out"
               />
               <label htmlFor="remember_me" className="ml-2 block text-sm leading-5 text-gray-900">
@@ -122,9 +122,8 @@ function App() {
             </div>
 
             <div className="text-sm leading-5">
-            {/* eslint-disable-next-line */}
+              {/* eslint-disable-next-line */}
               <a
-
                 onClick={forgotPassword}
                 href="/"
                 className="font-medium text-indigo-600 hover:text-indigo-500 focus:outline-none focus:underline transition ease-in-out duration-150"

--- a/src/GoTrueApi.ts
+++ b/src/GoTrueApi.ts
@@ -1,13 +1,21 @@
 import { get, post, put } from './lib/fetch'
-import { Session, User, Provider, UserAttributes } from './lib/types'
+import { Session, Provider, UserAttributes } from './lib/types'
 
 export default class GoTrueApi {
-  url: string
-  headers: {
+  protected url: string
+  protected headers: {
     [key: string]: string
   }
 
-  constructor({ url = '', headers = {} }: any) {
+  constructor({
+    url = '',
+    headers = {},
+  }: {
+    url: string
+    headers: {
+      [key: string]: string
+    }
+  }) {
     this.url = url
     this.headers = headers
   }
@@ -17,13 +25,12 @@ export default class GoTrueApi {
    * @param email The email address of the user.
    * @param password The password of the user.
    */
-  async signUpWithEmail(email: string, password: string) {
+  async signUpWithEmail(
+    email: string,
+    password: string
+  ): Promise<{ data: Session | null; error: Error | null }> {
     try {
-      let data: any = await post(
-        `${this.url}/signup`,
-        { email, password },
-        { headers: this.headers }
-      )
+      const data = await post(`${this.url}/signup`, { email, password }, { headers: this.headers })
       return { data, error: null }
     } catch (error) {
       return { data: null, error }
@@ -35,14 +42,17 @@ export default class GoTrueApi {
    * @param email The email address of the user.
    * @param password The password of the user.
    */
-  async signInWithEmail(email: string, password: string) {
+  async signInWithEmail(
+    email: string,
+    password: string
+  ): Promise<{ data: Session | null; error: Error | null }> {
     try {
-      let data: any = await post(
+      const data = await post(
         `${this.url}/token?grant_type=password`,
         { email, password },
         { headers: this.headers }
       )
-      return { data: data as Session, error: null }
+      return { data, error: null }
     } catch (error) {
       return { data: null, error }
     }
@@ -52,9 +62,9 @@ export default class GoTrueApi {
    * Sends a reset request to an email address.
    * @param email The email address of the user.
    */
-  async resetPasswordForEmail(email: string) {
+  async resetPasswordForEmail(email: string): Promise<{ data: {} | null; error: Error | null }> {
     try {
-      let data: any = await post(`${this.url}/forgotPassword`, { email }, { headers: this.headers })
+      const data = await post(`${this.url}/recover`, { email }, { headers: this.headers })
       return { data, error: null }
     } catch (error) {
       return { data: null, error }
@@ -65,14 +75,14 @@ export default class GoTrueApi {
    * Removes a logged-in session.
    * @param jwt A valid, logged-in JWT.
    */
-  async signOut(jwt: string) {
+  async signOut(jwt: string): Promise<{ error: Error | null }> {
     try {
       let headers = { ...this.headers }
       headers['Authorization'] = `Bearer ${jwt}`
-      let data = await post(`${this.url}/logout`, {}, { headers, noResolveJson: true })
-      return { data, error: null }
+      await post(`${this.url}/logout`, {}, { headers, noResolveJson: true })
+      return { error: null }
     } catch (error) {
-      return { data: null, error }
+      return { error }
     }
   }
 

--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -224,8 +224,10 @@ export default class GoTrueClient {
         token_type,
         user,
       }
-      if (options?.storeSession) this._saveSession(session)
-      this._notifyAllSubscribers('SIGNED_IN')
+      if (options?.storeSession) {
+        this._saveSession(session)
+        this._notifyAllSubscribers('SIGNED_IN')
+      }
       // Remove tokens from URL
       window.location.hash = ''
 

--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -224,10 +224,10 @@ export default class GoTrueClient {
         token_type,
         user,
       }
-      if (options?.storeSession) {
-        this._saveSession(session)
-        this._notifyAllSubscribers('SIGNED_IN')
-      }
+      if (options?.storeSession) this._saveSession(session)
+      this._notifyAllSubscribers('SIGNED_IN')
+      // Remove tokens from URL
+      window.location.hash = ''
 
       return { data: session, error: null }
     } catch (error) {

--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -13,6 +13,11 @@ const DEFAULT_OPTIONS = {
 }
 export default class GoTrueClient {
   /**
+   * Namespace for the GoTrue API methods.
+   * These can be used for example to get a user from a JWT in a server environment or reset a user's password.
+   */
+  api: GoTrueApi
+  /**
    * The currently logged in user or null.
    */
   protected currentUser: User | null
@@ -20,7 +25,6 @@ export default class GoTrueClient {
    * The session object for the currently logged in user or null.
    */
   protected currentSession: Session | null
-  protected api: GoTrueApi
   protected autoRefreshToken: boolean
   protected persistSession: boolean
   protected localStorage: Storage
@@ -71,7 +75,7 @@ export default class GoTrueClient {
   async signUp(credentials: {
     email: string
     password: string
-  }): Promise<{ data: Session | null; user: User | null; error: any }> {
+  }): Promise<{ data: Session | null; user: User | null; error: Error | null }> {
     try {
       this._removeSession()
 
@@ -83,7 +87,7 @@ export default class GoTrueClient {
         this._notifyAllSubscribers('SIGNED_IN')
       }
 
-      return { data, user: data.user, error: null }
+      return { data, user: data?.user ?? null, error: null }
     } catch (error) {
       return { data: null, user: null, error }
     }
@@ -105,7 +109,7 @@ export default class GoTrueClient {
     user: User | null
     provider?: Provider
     url?: string | null
-    error: any
+    error: Error | null
   }> {
     try {
       this._removeSession()
@@ -121,7 +125,7 @@ export default class GoTrueClient {
   /**
    * Returns the user data, if there is a logged in user.
    */
-  user(): { data: User | null; user: User | null; error: any } {
+  user(): { data: User | null; user: User | null; error: Error | null } {
     try {
       if (!this.currentSession?.access_token) throw new Error('Not logged in.')
 
@@ -134,7 +138,7 @@ export default class GoTrueClient {
   /**
    * Returns the session data, if there is an active session.
    */
-  session(): { data: Session | null; error: any } {
+  session(): { data: Session | null; error: Error | null } {
     try {
       if (!this.currentSession?.access_token) throw new Error('Not logged in.')
 
@@ -147,7 +151,11 @@ export default class GoTrueClient {
   /**
    * Force refreshes the session including the user data in case it was updated in a different session.
    */
-  async refreshSession(): Promise<{ data: Session | null; user: User | null; error: any }> {
+  async refreshSession(): Promise<{
+    data: Session | null
+    user: User | null
+    error: Error | null
+  }> {
     try {
       if (!this.currentSession?.access_token) throw new Error('Not logged in.')
 
@@ -168,7 +176,7 @@ export default class GoTrueClient {
    */
   async update(
     attributes: UserAttributes
-  ): Promise<{ data: User | null; user: User | null; error: any }> {
+  ): Promise<{ data: User | null; user: User | null; error: Error | null }> {
     try {
       if (!this.currentSession?.access_token) throw new Error('Not logged in.')
 
@@ -190,7 +198,7 @@ export default class GoTrueClient {
    */
   async getSessionFromUrl(options?: {
     storeSession?: boolean
-  }): Promise<{ data: Session | null; error: any }> {
+  }): Promise<{ data: Session | null; error: Error | null }> {
     try {
       if (!isBrowser()) throw new Error('No browser detected.')
 
@@ -230,17 +238,14 @@ export default class GoTrueClient {
   /**
    * Signs out the current user, if there is a logged in user.
    */
-  async signOut(): Promise<{ error: any }> {
-    try {
-      if (this.currentSession) {
-        await this.api.signOut(this.currentSession.access_token)
-      }
-      this._removeSession()
-      this._notifyAllSubscribers('SIGNED_OUT')
-      return { error: null }
-    } catch (error) {
-      return { error }
+  async signOut(): Promise<{ error: Error | null }> {
+    if (this.currentSession) {
+      const { error } = await this.api.signOut(this.currentSession.access_token)
+      if (error) return { error }
     }
+    this._removeSession()
+    this._notifyAllSubscribers('SIGNED_OUT')
+    return { error: null }
   }
 
   /**
@@ -249,7 +254,7 @@ export default class GoTrueClient {
    */
   onAuthStateChange(
     callback: (event: AuthChangeEvent, session: Session | null) => void
-  ): { data: Subscription | null; error: any } {
+  ): { data: Subscription | null; error: Error | null } {
     try {
       const id: string = uuid()
       let self = this
@@ -276,7 +281,7 @@ export default class GoTrueClient {
         this._saveSession(data)
         this._notifyAllSubscribers('SIGNED_IN')
       }
-      
+
       return { data, user: data.user, error: null }
     } catch (error) {
       return { data: null, user: null, error }

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -19,7 +19,7 @@ const handleError = (error: any, reject: any) => {
   }
 }
 
-export async function get(url: string, options?: FetchOptions) {
+export async function get(url: string, options?: FetchOptions): Promise<any> {
   return new Promise((resolve, reject) => {
     fetch(url, {
       method: 'GET',
@@ -34,7 +34,7 @@ export async function get(url: string, options?: FetchOptions) {
       .catch((error) => handleError(error, reject))
   })
 }
-export async function post(url: string, body: object, options?: FetchOptions) {
+export async function post(url: string, body: object, options?: FetchOptions): Promise<any> {
   return new Promise((resolve, reject) => {
     fetch(url, {
       method: 'POST',
@@ -50,7 +50,7 @@ export async function post(url: string, body: object, options?: FetchOptions) {
       .catch((error) => handleError(error, reject))
   })
 }
-export async function put(url: string, body: object, options?: FetchOptions) {
+export async function put(url: string, body: object, options?: FetchOptions): Promise<any> {
   return new Promise((resolve, reject) => {
     fetch(url, {
       method: 'PUT',

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -11,7 +11,7 @@ export const isBrowser = () => typeof window !== 'undefined'
 export function getParameterByName(name: string, url?: string) {
   if (!url) url = window.location.href
   name = name.replace(/[\[\]]/g, '\\$&')
-  var regex = new RegExp('[?&]' + name + '(=([^&#]*)|&|#|$)'),
+  var regex = new RegExp('[?&#]' + name + '(=([^&#]*)|&|#|$)'),
     results = regex.exec(url)
   if (!results) return null
   if (!results[2]) return ''

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -120,6 +120,6 @@ test('signIn() with the wrong password', async () => {
     email,
     password: password + '2',
   })
-  expect(error.message).toMatchSnapshot()
+  expect(error!.message).toMatchSnapshot()
   expect(data).toBeNull()
 })

--- a/test/subscriptions.test.ts
+++ b/test/subscriptions.test.ts
@@ -7,7 +7,6 @@ describe('Developers can subscribe and unsubscribe', () => {
   const { data: subscription } = gotrue.onAuthStateChange(() => console.log('called'))
 
   test('Subscribe a listener', async () => {
-    
     // @ts-ignore
     expect(gotrue.stateChangeEmmitters.size).toMatchSnapshot()
   })


### PR DESCRIPTION
## What kind of change does this PR introduce?

- expose `GoTrueAPI` from `GotrueClient`
- Type errors as Error objects
- Fix `getParameterByName` to recognize hash `#`
- Remove hash from URL once session has been restored