### PR TITLE
feat: Add magic link api method and sign in.

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,6 +1,10 @@
-# Releases 
+# Releases
 
 Releases are handled by Semantic release. This document is for forcing and documenting any non-code changes.
+
+### v1.7.0
+
+In this release we added `client.api.sendMagicLinkEmail()` and updated `client.signIn()` to support magic link login by only providing email credentials without a password.
 
 ### v1.6.1
 
@@ -10,7 +14,6 @@ In this release we strip out the session data from the URL once it is detected.
 
 In this release we added `client.user()`, `client.session()`, and `client.refreshSession()`.
 
-
 ### v1.5.10
 
 In this one we had to roll back the automatic Semantic release, which bumped the version to 2.0.0.
@@ -18,7 +21,7 @@ In this one we had to roll back the automatic Semantic release, which bumped the
 This release containes some breaking changes:
 
 ```js
-// previously 
+// previously
 let client = new Client()
 
 // this release

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -25,7 +25,8 @@ function App() {
     } else {
       localStorage.removeItem('email')
     }
-    let { error } = await auth.signIn({ email, password })
+    let { error, user } = await auth.signIn({ email, password })
+    if (!error && !user) alert('Check your email for the login link!')
     if (error) console.log('Error: ', error.message)
   }
   async function handleEmailSignUp() {
@@ -140,7 +141,7 @@ function App() {
                 type="button"
                 className="w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-500 focus:outline-none focus:border-indigo-700 focus:shadow-outline-indigo active:bg-indigo-700 transition duration-150 ease-in-out"
               >
-                Sign In
+                {password.length ? 'Sign in' : 'Send magic link'}
               </button>
             </span>
             <span className="block w-full rounded-md shadow-sm">

--- a/src/GoTrueApi.ts
+++ b/src/GoTrueApi.ts
@@ -59,6 +59,19 @@ export default class GoTrueApi {
   }
 
   /**
+   * Sends a magic login link to an email address.
+   * @param email The email address of the user.
+   */
+  async sendMagicLinkEmail(email: string): Promise<{ data: {} | null; error: Error | null }> {
+    try {
+      const data = await post(`${this.url}/magiclink`, { email }, { headers: this.headers })
+      return { data, error: null }
+    } catch (error) {
+      return { data: null, error }
+    }
+  }
+
+  /**
    * Sends a reset request to an email address.
    * @param email The email address of the user.
    */

--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -113,7 +113,11 @@ export default class GoTrueClient {
   }> {
     try {
       this._removeSession()
-      let { email, password, provider } = credentials
+      const { email, password, provider } = credentials
+      if (email && !password) {
+        const { error } = await this.api.sendMagicLinkEmail(email)
+        return { data: null, user: null, error }
+      }
       if (email && password) return this._handeEmailSignIn(email, password)
       if (provider) return this._handeProviderSignIn(provider)
       else throw new Error(`You must provide either an email or a third-party provider.`)


### PR DESCRIPTION
r? @kiwicopple @awalias 

## What kind of change does this PR introduce?

### v1.7.0

In this release we added `client.api.sendMagicLinkEmail()` and updated `client.signIn()` to support magic link login by only providing email credentials without a password.

### Example

Update the example to say 'Send magic link' instead of 'Sign in' on the button when no password input is provided

### TODO

- [x] Wait for supabase/gotrue infra update to be deployed and test that it actually works. cc @awalias 