### PR TITLE
feat: adds inviteUserByEmail for api users

### DIFF
--- a/src/GoTrueApi.ts
+++ b/src/GoTrueApi.ts
@@ -72,6 +72,19 @@ export default class GoTrueApi {
   }
 
   /**
+   * Sends an invite link to an email address.
+   * @param email The email address of the user.
+   */
+  async inviteUserByEmail(email: string): Promise<{ data: {} | null; error: Error | null }> {
+    try {
+      const data = await post(`${this.url}/invite`, { email }, { headers: this.headers })
+      return { data, error: null }
+    } catch (error) {
+      return { data: null, error }
+    }
+  }
+
+  /**
    * Sends a reset request to an email address.
    * @param email The email address of the user.
    */


### PR DESCRIPTION
Have tested successfully against a supabase instance with:

```javascript
let { GoTrueClient } = require("@supabase/gotrue-js");

const auth = new GoTrueClient({
  url: "http://<ref>.supabase.co/auth/v1/",
  headers: {
    apikey:
      "<SUPABASE_SERVICE_ROLE_KEY> or <SUPABASE_ANON_KEY>",
    Authorization:
      "Bearer <SUPABASE_SERVICE_ROLE_KEY>",
  },
});

auth.api
  .inviteUserByEmail("ant@supabase.io" )
  .then(console.log)
  .catch(console.error);

```