### PR TITLE
feat: add export of types for downstream use

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,3 +2,4 @@ import GoTrueApi from './GoTrueApi'
 import GoTrueClient from './GoTrueClient'
 
 export { GoTrueApi, GoTrueClient }
+export * from './lib/types'


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature: https://github.com/supabase/gotrue-js/issues/28

## What is the current behavior?

The library does not export types

## What is the new behavior?

Export the gotrue-js types so they can be used in upstream libraries.

## Additional context

This PR will be followed by a PR to the supabase-js library so that all necessary types (gotrue, supabase, realtime) are available in TypeScript projects.
