### PR TITLE
fix: Fire signed in event on recoverSession.

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -326,6 +326,7 @@ export default class GoTrueClient {
   }
 
   private async _recoverSession() {
+    // Note: this method is async to accomodate for AsyncStorage e.g. in React native.
     const json = isBrowser() && (await this.localStorage.getItem(STORAGE_KEY))
     if (json) {
       try {
@@ -342,6 +343,7 @@ export default class GoTrueClient {
         } else {
           this.currentSession = currentSession
           this.currentUser = currentSession.user
+          this._notifyAllSubscribers('SIGNED_IN')
           // schedule a refresh 60 seconds before token due to expire
           setTimeout(this._callRefreshToken, (expiresAt - timeNow - 60) * 1000)
         }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes #23 

For environments where localstorage is async (e.g. AsyncStorage on React Native), fire a `SIGNED_IN` `onAuthStateChange` event as soon as the session has been recovered from localStorage.

That way the following pattern should solve things across the board: https://github.com/thorwebdev/nextjs-subscription-payments/blob/main/components/UserContext.js#L13-L28

```js
useEffect(() => {
    const session = supabase.auth.session();
    setSession(session);
    setUser(session?.user ?? null);
    const { data: authListener } = supabase.auth.onAuthStateChange(
      async (event, session) => {
        setSession(session);
        setUser(session?.user ?? null);
      }
    );

    return () => {
      authListener.unsubscribe();
    };
    // eslint-disable-next-line react-hooks/exhaustive-deps
  }, []);
```
