### PR TITLE
Don't error if process is undefined

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,5 +1,5 @@
-export const GOTRUE_URL = process.env.GOTRUE_URL || 'http://localhost:9999'
-export const AUDIENCE = process.env.AUDIENCE || ''
+export const GOTRUE_URL = process?.env?.GOTRUE_URL || 'http://localhost:9999'
+export const AUDIENCE = process?.env?.AUDIENCE || ''
 export const DEFAULT_HEADERS = {}
-export const EXPIRY_MARGIN = process.env.EXPIRY_MARGIN || 60 * 1000
-export const STORAGE_KEY = process.env.STORAGE_KEY || 'supabase.auth.token'
+export const EXPIRY_MARGIN = process?.env?.EXPIRY_MARGIN || 60 * 1000
+export const STORAGE_KEY = process?.env?.STORAGE_KEY || 'supabase.auth.token'


### PR DESCRIPTION
## What kind of change does this PR introduce?

Loading this SDK in a browser context that does not have `process.env` defined currently throws an error. This fixes it so it handles if `process` is `undefined`.
