### PR TITLE
fix: fire PASSWORD_RECOVERY auth event

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -232,6 +232,9 @@ export default class GoTrueClient {
       if (options?.storeSession) {
         this._saveSession(session)
         this._notifyAllSubscribers('SIGNED_IN')
+        if (getParameterByName('type') === 'recovery') {
+          this._notifyAllSubscribers('PASSWORD_RECOVERY')
+        }
       }
       // Remove tokens from URL
       window.location.hash = ''

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,6 +1,6 @@
 export type Provider = 'bitbucket' | 'github' | 'gitlab' | 'google'
 
-export type AuthChangeEvent = 'SIGNED_IN' | 'SIGNED_OUT' | 'USER_UPDATED'
+export type AuthChangeEvent = 'SIGNED_IN' | 'SIGNED_OUT' | 'USER_UPDATED' | 'PASSWORD_RECOVERY'
 
 export interface Session {
   access_token: string


### PR DESCRIPTION
Closes #39 

## What kind of change does this PR introduce?

To help with resetting a user’s password I’m proposing to add another `onAuthChange` event called `PASSWORD_RECOVERY`.

This will help folks detect that someone has clicked on a recovery link and show the appropriate dialog. And to help with the dialog, I’ve added a `Auth.UpdatePassword` component: https://github.com/supabase/ui/pull/57. 

r? @kiwicopple @ykdojo