### PR TITLE
Enable passing scopes to provider

### DIFF
--- a/src/GoTrueApi.ts
+++ b/src/GoTrueApi.ts
@@ -184,16 +184,21 @@ export default class GoTrueApi {
    * Generates the relevant login URL for a third-party provider.
    * @param provider One of the providers supported by GoTrue.
    * @param redirectTo A URL or mobile address to send the user to after they are confirmed.
+   * @param scopes A space separated list of scopes granted to the OAuth application
    */
   getUrlForProvider(
     provider: Provider,
     options: {
       redirectTo?: string
+      scopes?: string
     }
   ) {
     let urlParams: string[] = [`provider=${provider}`]
     if (options?.redirectTo) {
       urlParams.push(`redirect_to=${options.redirectTo}`)
+    }
+    if (options?.scopes) {
+      urlParams.push(`scopes=${options.scopes}`)
     }
     return `${this.url}/authorize?${urlParams.join('&')}`
   }

--- a/src/GoTrueApi.ts
+++ b/src/GoTrueApi.ts
@@ -184,7 +184,7 @@ export default class GoTrueApi {
    * Generates the relevant login URL for a third-party provider.
    * @param provider One of the providers supported by GoTrue.
    * @param redirectTo A URL or mobile address to send the user to after they are confirmed.
-   * @param scopes A space separated list of scopes granted to the OAuth application
+   * @param scopes A space-separated list of scopes granted to the OAuth application.
    */
   getUrlForProvider(
     provider: Provider,

--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -143,7 +143,7 @@ export default class GoTrueClient {
    * @param password The user's password.
    * @param provider One of the providers supported by GoTrue.
    * @param redirectTo A URL or mobile address to send the user to after they are confirmed.
-   * @param scopes A space separated list of scopes granted to the OAuth application
+   * @param scopes A space-separated list of scopes granted to the OAuth application.
    */
   async signIn(
     { email, password, provider }: UserCredentials,

--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -261,6 +261,7 @@ export default class GoTrueClient {
       const error_description = getParameterByName('error_description')
       if (error_description) throw new Error(error_description)
 
+      const provider_token = getParameterByName('provider_token')
       const access_token = getParameterByName('access_token')
       if (!access_token) throw new Error('No access_token detected.')
       const expires_in = getParameterByName('expires_in')
@@ -274,6 +275,7 @@ export default class GoTrueClient {
       if (error) throw error
 
       const session: Session = {
+        provider_token,
         access_token,
         expires_in: parseInt(expires_in),
         refresh_token,

--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -143,11 +143,13 @@ export default class GoTrueClient {
    * @param password The user's password.
    * @param provider One of the providers supported by GoTrue.
    * @param redirectTo A URL or mobile address to send the user to after they are confirmed.
+   * @param scopes A space separated list of scopes granted to the OAuth application
    */
   async signIn(
     { email, password, provider }: UserCredentials,
     options: {
       redirectTo?: string
+      scopes?: string
     } = {}
   ): Promise<{
     session: Session | null
@@ -174,6 +176,7 @@ export default class GoTrueClient {
       if (provider) {
         return this._handleProviderSignIn(provider, {
           redirectTo: options.redirectTo,
+          scopes: options.scopes,
         })
       }
       throw new Error(`You must provide either an email or a third-party provider.`)
@@ -361,9 +364,13 @@ export default class GoTrueClient {
     provider: Provider,
     options: {
       redirectTo?: string
+      scopes?: string
     } = {}
   ) {
-    const url: string = this.api.getUrlForProvider(provider, { redirectTo: options.redirectTo })
+    const url: string = this.api.getUrlForProvider(provider, {
+      redirectTo: options.redirectTo,
+      scopes: options.scopes,
+    })
 
     try {
       // try to open on the browser

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -3,6 +3,7 @@ export type Provider = 'azure' | 'bitbucket' | 'facebook' | 'github' | 'gitlab' 
 export type AuthChangeEvent = 'SIGNED_IN' | 'SIGNED_OUT' | 'USER_UPDATED' | 'PASSWORD_RECOVERY'
 
 export interface Session {
+  provider_token?: string | null
   access_token: string
   expires_in: number
   refresh_token: string

--- a/test/__snapshots__/provider.test.ts.snap
+++ b/test/__snapshots__/provider.test.ts.snap
@@ -7,3 +7,11 @@ exports[`signIn() with Provider 2`] = `"google"`;
 exports[`signIn() with Provider can append a redirectUrl  1`] = `"http://localhost:9999/authorize?provider=google&redirect_to=https://localhost:9000/welcome"`;
 
 exports[`signIn() with Provider can append a redirectUrl  2`] = `"google"`;
+
+exports[`signIn() with Provider can append multiple options 1`] = `"http://localhost:9999/authorize?provider=github&redirect_to=https://localhost:9000/welcome&scopes=repo"`;
+
+exports[`signIn() with Provider can append multiple options 2`] = `"github"`;
+
+exports[`signIn() with Provider can append scopes 1`] = `"http://localhost:9999/authorize?provider=github&scopes=repo"`;
+
+exports[`signIn() with Provider can append scopes 2`] = `"github"`;

--- a/test/provider.test.ts
+++ b/test/provider.test.ts
@@ -30,3 +30,32 @@ test('signIn() with Provider can append a redirectUrl ', async () => {
   expect(url).toMatchSnapshot()
   expect(provider).toMatchSnapshot()
 })
+
+test('signIn() with Provider can append scopes', async () => {
+  let { error, url, provider } = await auth.signIn(
+    {
+      provider: 'github',
+    },
+    {
+      scopes: 'repo',
+    }
+  )
+  expect(error).toBeNull()
+  expect(url).toMatchSnapshot()
+  expect(provider).toMatchSnapshot()
+})
+
+test('signIn() with Provider can append multiple options', async () => {
+  let { error, url, provider } = await auth.signIn(
+    {
+      provider: 'github',
+    },
+    {
+      redirectTo: 'https://localhost:9000/welcome',
+      scopes: 'repo',
+    }
+  )
+  expect(error).toBeNull()
+  expect(url).toMatchSnapshot()
+  expect(provider).toMatchSnapshot()
+})


### PR DESCRIPTION
## What kind of change does this PR introduce?

Allows a user to request scopes while signing up/in with an OAuth provider, and returns `provider_token` which allows access to the provider's API.

```
const { user, session, error } = await supabase.auth.signIn({
  provider: 'github'
}, {
  scopes: 'repo notifications'
})
```
