### PR TITLE
fix: persist updated user data to storage

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -240,6 +240,9 @@ export default class GoTrueClient {
       if (error) throw error
 
       this.currentUser = data
+      const session = {...this.currentSession, user: data!}
+      this.currentSession = session
+      this._saveSession(session)
       this._notifyAllSubscribers('USER_UPDATED')
 
       return { data, user: this.currentUser, error: null }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix GoTrueClient.update() to persist updated data to storage.

## What is the current behavior?

GoTrueClient.update() doesn't persist updated user data to storage. It's only update currentUser object in memory.

When users refresh the browser, user data will be reverted and out of sync. 

## What is the new behavior?

after updating user data, persist the new data to storage.

## Additional context

#49 
