### PR TITLE
fix: call token refreshing with arrow function

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -471,7 +471,7 @@ export default class GoTrueClient {
         this.currentUser = currentSession.user
         this._notifyAllSubscribers('SIGNED_IN')
         // schedule a refresh 60 seconds before token due to expire
-        setTimeout(this._callRefreshToken, (expiresAt - timeNow - 60) * 1000)
+        setTimeout(() => this._callRefreshToken(), (expiresAt - timeNow - 60) * 1000)
       }
     } catch (err) {
       console.error(err)
@@ -493,7 +493,7 @@ export default class GoTrueClient {
         const tokenExpirySeconds = data.expires_in
 
         if (this.autoRefreshToken && tokenExpirySeconds) {
-          setTimeout(this._callRefreshToken, (tokenExpirySeconds - 60) * 1000)
+          setTimeout(() => this._callRefreshToken(), (tokenExpirySeconds - 60) * 1000)
         }
 
         if (this.persistSession && this.currentUser) {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Call function for refreshing tokens correctly, so the method does not lose access to correct this object.

## What is the current behavior?

Method _callRefreshToken is passed directly into the setTimeout function, which causes that the _callRefreshToken method is called with a global object as this. 

## What is the new behavior?

Method _callRefreshToken is now called inside of arrow function which, assures correct this value inside the method.

## Additional context

This bug caused problems in my Expo application, I'm not sure if this bugfix is relevant on the web.
