### PR TITLE
fix: refresh access token

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -37,6 +37,7 @@ export default class GoTrueClient {
    * The session object for the currently logged in user or null.
    */
   protected currentSession: Session | null
+
   protected autoRefreshToken: boolean
   protected persistSession: boolean
   protected localStorage: Storage
@@ -214,12 +215,10 @@ export default class GoTrueClient {
     try {
       if (!this.currentSession?.access_token) throw new Error('Not logged in.')
 
-      await this._callRefreshToken()
-
-      const { data, error } = await this.api.getUser(this.currentSession.access_token)
+      // currentSession and currentUser will be updated to latest on _callRefreshToken
+      const { error } = await this._callRefreshToken()
       if (error) throw error
 
-      this.currentUser = data
       return { data: this.currentSession, user: this.currentUser, error: null }
     } catch (error) {
       return { data: null, user: null, error }
@@ -235,19 +234,18 @@ export default class GoTrueClient {
     try {
       if (!this.currentSession?.access_token) throw new Error('Not logged in.')
 
-      const { data, error } = await this.api.updateUser(
+      const { user, error } = await this.api.updateUser(
         this.currentSession.access_token,
         attributes
       )
       if (error) throw error
+      if (!user) throw Error('Invalid user data.')
 
-      this.currentUser = data
-      const session = { ...this.currentSession, user: data! }
-      this.currentSession = session
+      const session = { ...this.currentSession, user }
       this._saveSession(session)
       this._notifyAllSubscribers('USER_UPDATED')
 
-      return { data, user: this.currentUser, error: null }
+      return { data: user, user, error: null }
     } catch (error) {
       return { data: null, user: null, error }
     }
@@ -396,26 +394,6 @@ export default class GoTrueClient {
     }
   }
 
-  private _saveSession(session: Session) {
-    this.currentSession = session
-    this.currentUser = session.user
-
-    if (this.persistSession && session.expires_at) {
-      this._persistSession(this.currentSession)
-    }
-  }
-
-  private _persistSession(currentSession: Session) {
-    const data = { currentSession, expiresAt: currentSession.expires_at }
-    isBrowser() && this.localStorage.setItem(STORAGE_KEY, JSON.stringify(data))
-  }
-
-  private async _removeSession() {
-    this.currentSession = null
-    this.currentUser = null
-    isBrowser() && (await this.localStorage.removeItem(STORAGE_KEY))
-  }
-
   /**
    * Attempts to get the session from LocalStorage
    * Note: this should never be async (even for React Native), as we need it to return immediately in the constructor.
@@ -432,8 +410,7 @@ export default class GoTrueClient {
       const timeNow = Math.round(Date.now() / 1000)
 
       if (expiresAt > timeNow && currentSession?.user) {
-        this.currentSession = currentSession
-        this.currentUser = currentSession.user
+        this._saveSession(currentSession)
       }
     } catch (error) {
       console.log('error', error)
@@ -468,13 +445,8 @@ export default class GoTrueClient {
         console.log('Current session is missing data.')
         this._removeSession()
       } else {
-        this.currentSession = currentSession
-        this.currentUser = currentSession.user
+        this._saveSession(currentSession)
         this._notifyAllSubscribers('SIGNED_IN')
-        // console.log('_recoverAndRefresh setTimeout: ', expiresAt, timeNow)
-        // setTimeout(() => this._callRefreshToken(), (expiresAt - timeNow - 60) * 1000)
-        // schedule a refresh 60 seconds before token due to expire
-        this._startRefreshTokenTimer((expiresAt - timeNow - 60) * 1000)
       }
     } catch (err) {
       console.error(err)
@@ -488,25 +460,12 @@ export default class GoTrueClient {
         throw new Error('No current session.')
       }
       const { data, error } = await this.api.refreshAccessToken(refresh_token)
+      if (error) throw error
+      if (!data) throw Error('Invalid session data.')
 
-      if (data?.access_token) {
-        this.currentSession = data as Session
-        this.currentUser = this.currentSession.user
-        this._notifyAllSubscribers('SIGNED_IN')
-        const tokenExpirySeconds = data.expires_in
+      this._saveSession(data)
+      this._notifyAllSubscribers('SIGNED_IN')
 
-        if (this.autoRefreshToken && tokenExpirySeconds) {
-          // console.log('_callRefreshToken setTimeout:', tokenExpirySeconds)
-          // setTimeout(() => this._callRefreshToken(), (tokenExpirySeconds - 60) * 1000)
-          this._startRefreshTokenTimer((tokenExpirySeconds - 60) * 1000)
-        }
-
-        if (this.persistSession && this.currentUser) {
-          this._persistSession(this.currentSession)
-        }
-      } else {
-        throw error
-      }
       return { data, error: null }
     } catch (error) {
       return { data: null, error }
@@ -518,10 +477,44 @@ export default class GoTrueClient {
   }
 
   /**
+   * set currentSession and currentUser
+   * process to _startAutoRefreshToken if possible
+   */
+  private _saveSession(session: Session) {
+    this.currentSession = session
+    this.currentUser = session.user
+
+    const expiresAt = session.expires_at
+    const timeNow = Math.round(Date.now() / 1000)
+    if (expiresAt) this._startAutoRefreshToken((expiresAt - timeNow - 60) * 1000)
+
+    // Do we need any extra check before persist session
+    // access_token or user ?
+    if (this.persistSession && session.expires_at) {
+      this._persistSession(this.currentSession)
+    }
+  }
+
+  private _persistSession(currentSession: Session) {
+    const data = { currentSession, expiresAt: currentSession.expires_at }
+    isBrowser() && this.localStorage.setItem(STORAGE_KEY, JSON.stringify(data))
+  }
+
+  private async _removeSession() {
+    this.currentSession = null
+    this.currentUser = null
+    isBrowser() && (await this.localStorage.removeItem(STORAGE_KEY))
+  }
+
+  /**
    * Clear and re-create refresh token timer
    * @param value time intervals in milliseconds
    */
-  private _startRefreshTokenTimer(value: number) {
+  private _startAutoRefreshToken(value: number) {
+    if (!value) return
+    if (!this.autoRefreshToken) return
+
+    console.log('_startAutoRefreshToken: ', value)
     if (this.refreshTokenTimer) clearTimeout(this.refreshTokenTimer)
     this.refreshTokenTimer = setTimeout(() => this._callRefreshToken(), value)
   }

--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -420,9 +420,9 @@ export default class GoTrueClient {
 
   /**
    * Recovers the session from LocalStorage and refreshes
+   * Note: this method is async to accommodate for AsyncStorage e.g. in React native.
    */
   private async _recoverAndRefresh() {
-    // Note: this method is async to accommodate for AsyncStorage e.g. in React native.
     try {
       const json = isBrowser() && (await this.localStorage.getItem(STORAGE_KEY))
       if (!json) {

--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -506,6 +506,7 @@ export default class GoTrueClient {
   private async _removeSession() {
     this.currentSession = null
     this.currentUser = null
+    if (this.refreshTokenTimer) clearTimeout(this.refreshTokenTimer)
     isBrowser() && (await this.localStorage.removeItem(STORAGE_KEY))
   }
 

--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -517,7 +517,6 @@ export default class GoTrueClient {
     if (this.refreshTokenTimer) clearTimeout(this.refreshTokenTimer)
     if (!value || !this.autoRefreshToken) return
 
-    console.log('_startAutoRefreshToken: ', value)
     this.refreshTokenTimer = setTimeout(() => this._callRefreshToken(), value)
   }
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?



## What is the current behavior?

- auto refresh token timer only triggers when there is an existed token on storage. When user login the first time, the jwt token will expire and not auto refresh.
- doesn't keep reference of refresh token timer to cancel when starting a new one
- multiple places update currentSession and currentUser

## What is the new behavior?

- use `_saveSession` to update currentSession and currentUser
- `_saveSession` will also trigger auto refresh token
- keep auto refresh token reference so that we can cancel it before starting a new one. One 1 will run at a time.
- code refactoring

#70 #61 