### PR TITLE
fix: recognise .local vhost and send insecure cookie

### DIFF
--- a/src/lib/cookies.ts
+++ b/src/lib/cookies.ts
@@ -116,7 +116,7 @@ function isSecureEnvironment(req: any) {
 
   const host =
     (req.headers.host.indexOf(':') > -1 && req.headers.host.split(':')[0]) || req.headers.host
-  if (['localhost', '127.0.0.1'].indexOf(host) > -1) {
+  if (['localhost', '127.0.0.1'].indexOf(host) > -1 || host.endsWith('.local')) {
     return false
   }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes #81 

## What is the current behavior?

Cookie is sent as `Secure` when using a vhost in a local development environment

## What is the new behavior?

Recognise vhosts ending in `.local` and don't send a `Secure` cookie.

## Additional context

Potentially a better fix would be to have the user customise if the cookie should be secure or not.
