### PR TITLE
Use in a node context

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -252,10 +252,10 @@ export default class GoTrueClient {
   }
 
   /**
-   * Overrides the JWT on the current client which will then be used in all subsequent requests.
+   * Overrides the JWT on the current client. The JWT will then be sent in all subsequent network requests.
    * @param access_token a jwt access token
    */
-  setUser(access_token: string): Session {
+  setAuth(access_token: string): Session {
     this.currentSession = {
       ...this.currentSession,
       access_token,

--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -252,7 +252,7 @@ export default class GoTrueClient {
   }
 
   /**
-   * Sets the current user.
+   * Overrides the JWT on the current client which will then be used in all subsequent requests.
    * @param access_token a jwt access token
    */
   setUser(access_token: string): Session {

--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -252,6 +252,21 @@ export default class GoTrueClient {
   }
 
   /**
+   * Sets the current user.
+   * @param access_token a jwt access token
+   */
+  setUser(access_token: string): Session {
+    this.currentSession = {
+      ...this.currentSession,
+      access_token,
+      token_type: 'bearer',
+      user: null,
+    }
+
+    return this.currentSession
+  }
+
+  /**
    * Gets the session data from a URL string
    * @param options.storeSession Optionally store the session in the browser
    */

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -13,9 +13,9 @@ export interface Session {
    * A timestamp of when the token will expire. Returned when a login is confirmed.
    */
   expires_at?: number
-  refresh_token: string
+  refresh_token?: string
   token_type: string
-  user: User
+  user: User | null
 }
 export interface User {
   id: string

--- a/test/clientWithAutoConfirmEnabled.test.ts
+++ b/test/clientWithAutoConfirmEnabled.test.ts
@@ -11,12 +11,14 @@ const auth = new GoTrueClient({
 
 const email = `client_ac_enabled_${faker.internet.email()}`
 const password = faker.internet.password()
+var access_token: string | null = null
 
 test('signUp()', async () => {
   let { error, user, session } = await auth.signUp({
     email,
     password,
   })
+  access_token = session?.access_token || null
   expect(error).toBeNull()
   expect(session).toMatchSnapshot({
     access_token: expect.any(String),
@@ -60,6 +62,23 @@ test('signUp() the same user twice should throw an error', async () => {
   expect(data).toBeNull()
   expect(user).toBeNull()
 })
+
+
+test('setUser() set the Auth headers on a new client', async () => {
+  expect(access_token).toBeTruthy()
+
+  const newClient = new GoTrueClient({
+    url: GOTRUE_URL,
+    autoRefreshToken: false,
+    persistSession: false,
+  })
+
+  newClient.setUser(access_token!)
+
+  const authBearer = newClient.session()?.access_token
+  expect(authBearer).toEqual(access_token)
+})
+
 
 test('signIn()', async () => {
   let { error, session, user } = await auth.signIn({

--- a/test/clientWithAutoConfirmEnabled.test.ts
+++ b/test/clientWithAutoConfirmEnabled.test.ts
@@ -64,7 +64,7 @@ test('signUp() the same user twice should throw an error', async () => {
 })
 
 
-test('setUser() set the Auth headers on a new client', async () => {
+test('setAuth() should set the Auth headers on a new client', async () => {
   expect(access_token).toBeTruthy()
 
   const newClient = new GoTrueClient({
@@ -73,7 +73,7 @@ test('setUser() set the Auth headers on a new client', async () => {
     persistSession: false,
   })
 
-  newClient.setUser(access_token!)
+  newClient.setAuth(access_token!)
 
   const authBearer = newClient.session()?.access_token
   expect(authBearer).toEqual(access_token)


### PR DESCRIPTION
This adds the minimum viable context to set the auth headers required for supabase-js:

https://github.com/supabase/supabase-js/blob/906a076c8942fe86765f0b9430be5b0ad076036a/src/SupabaseClient.ts#L172
