### PR TITLE
fix: notify subscribers when setting session

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -274,6 +274,7 @@ export default class GoTrueClient {
       }
 
       this._saveSession(data)
+      this._notifyAllSubscribers('SIGNED_IN')
       return { session: data, error: null }
     } catch (error) {
       return { error, session: null }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Notifies subscribers when using `setSession`

## Additional context

I'm not sure if this is entirely correct behavior, since `setSession` could be used to refresh the session rather than initiate it, resulting in an extraneous `SIGN_IN` event. We could add an additional check if it seems appropriate.

This fixes an issue for me when manually signing in a user with a refresh_token. I want `SIGN_IN` to fire so my app redirects like a normal session change.