### PR TITLE
fix: globalThis polyfill for Mobile Safari <= 12.0

### DIFF
--- a/src/lib/polyfills.ts
+++ b/src/lib/polyfills.ts
@@ -5,12 +5,18 @@
  */
 export function polyfillGlobalThis() {
   if (typeof globalThis === 'object') return
-  Object.defineProperty(Object.prototype, '__magic__', {
-    get: function () {
-      return this
-    },
-    configurable: true,
-  })
-  __magic__.globalThis = __magic__
-  delete Object.prototype.__magic__
+  try {
+    Object.defineProperty(Object.prototype, '__magic__', {
+      get: function () {
+        return this
+      },
+      configurable: true,
+    })
+    __magic__.globalThis = __magic__
+    delete Object.prototype.__magic__
+  } catch (e) {
+    if (typeof self !== 'undefined') {
+      self.globalThis = self
+    }
+  }
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes Mobile Safari <= 12.0 support.

## What is the current behavior?

Library is not consumable on Mobile Safari <= 12.0 due to a bad polyfill for `globalThis`.

For my case (a Next.js page) this leads to the entire webpage being just a blank white screen:

![Screen Shot 2021-05-23 at 1 10 26 am](https://user-images.githubusercontent.com/482276/119231335-beab8400-bb63-11eb-8c8f-5810a9156b65.png)

As per the above screenshot, the failing (and corrected) behaviour can be verified from an iOS 12.1 Simulator.

## What is the new behavior?

If the current polyfill fails, fallback to a simple `self.globalThis = self` polyfill, which will be correct for any sane browser:
* https://caniuse.com/?search=self
* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis
    * > On the web you can use window, self, or frames - but in Web Workers only self will work.

## Additional context

The original polyfill comes from https://mathiasbynens.be/notes/globalthis. However, that blog post makes few guarantees regarding browser support. There's actually a note explaining when the polyfill may fail: 

> Note: Prior to the globalThis proposal, the ECMAScript spec doesn’t actually mandate that the global this inherit from Object.prototype, only that it must be an object. Object.create(null) creates an object that doesn’t inherit from Object.prototype. A JavaScript engine could use such an object as the global this without violating the spec, in which case the above code snippet still wouldn’t work (and indeed, Internet Explorer 7 did something like that!). Luckily, more modern JavaScript engines all seem to agree that the global this must have Object.prototype in its prototype chain.

IE7 is mentioned, but this is also the case for Mobile Safari <= 12.0.