### PR TITLE
fix: /invite API (inviteUserByEmail) returns a User

### DIFF
--- a/src/GoTrueApi.ts
+++ b/src/GoTrueApi.ts
@@ -121,7 +121,7 @@ export default class GoTrueApi {
     options: {
       redirectTo?: string
     } = {}
-  ): Promise<{ data: {} | null; error: Error | null }> {
+  ): Promise<{ data: User | null; error: Error | null }> {
     try {
       let headers = { ...this.headers }
       if (options.redirectTo) {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Corrected the return type of `inviteUserByEmail`.

The `/invite` API returns a User object as per https://github.com/supabase/gotrue/blob/master/api/invite.go#L73

## What is the current behavior?

`inviteUserByEmail` returned promise result `data` property is typed as `{}`, rather than `User`.

## What is the new behavior?

`inviteUserByEmail` returned promise result `data` property is now typed as `User`, matching the data returned from the `/invite` API.

## Additional context

