### PR TITLE
(Proof-of-concept) Adding user metadata with signup

### DIFF
--- a/src/GoTrueApi.ts
+++ b/src/GoTrueApi.ts
@@ -50,7 +50,7 @@ export default class GoTrueApi {
       if (options.redirectTo) {
         queryString = '?redirect_to=' + options.redirectTo
       }
-      const data = await post(`${this.url}/signup${queryString}`, { email, password, data:user_metadata }, { headers })
+      const data = await post(`${this.url}/signup${queryString}`, { email, password, data: options.user_metadata }, { headers })
       let session = { ...data }
       if (session.expires_in) session.expires_at = expiresAt(data.expires_in)
       return { data: session, error: null }

--- a/src/GoTrueApi.ts
+++ b/src/GoTrueApi.ts
@@ -40,6 +40,7 @@ export default class GoTrueApi {
     email: string,
     password: string,
     options: {
+      user_metadata?: object,
       redirectTo?: string
     } = {}
   ): Promise<{ data: Session | User | null; error: Error | null }> {
@@ -49,7 +50,7 @@ export default class GoTrueApi {
       if (options.redirectTo) {
         queryString = '?redirect_to=' + options.redirectTo
       }
-      const data = await post(`${this.url}/signup${queryString}`, { email, password }, { headers })
+      const data = await post(`${this.url}/signup${queryString}`, { email, password, data:user_metadata }, { headers })
       let session = { ...data }
       if (session.expires_in) session.expires_at = expiresAt(data.expires_in)
       return { data: session, error: null }

--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -96,7 +96,8 @@ export default class GoTrueClient {
   async signUp(
     { email, password }: UserCredentials,
     options: {
-      redirectTo?: string
+      redirectTo?: string,
+      user_metadata?: object
     } = {}
   ): Promise<{
     user: User | null
@@ -109,6 +110,7 @@ export default class GoTrueClient {
 
       const { data, error } = await this.api.signUpWithEmail(email!, password!, {
         redirectTo: options.redirectTo,
+        user_metadata: options.user_metadata,
       })
 
       if (error) {


### PR DESCRIPTION
## What kind of change does this PR introduce?
Lets you add metadata when signing up a user instead of having to sign up then update.

## What is the current behavior?
Adding arbitrary data to the auth.user table is only possible via the `update` call. 

## What is the new behavior?
You can optionally pass in user_metadata in the options object to add the metadata upon signup. 

## Additional context
I'm working on an app that has two types/levels of users, (e.g. teachers and students). The structure of user info stored for each is different enough that it makes more sense to have separate `public.students` and `public.teachers` tables. I was hoping to set up a trigger similar to the `handle_new_users` example described [in the guide](https://supabase.io/docs/guides/auth#create-a-publicusers-table) but right now when I call signup I don't actually know whether it's a student or a teacher so I don't know which table to make a new row in. So I'd have to do a post-signup update call or some sort of custom function, both of which just feel a little clunky. 

Here's where it gets _interesting_. While the [gotrue docs](https://github.com/supabase/gotrue#post-signup) imply you can only pass `{email, password}`, the [code itself](https://github.com/netlify/gotrue/blob/master/api/signup.go#L100) (and its [types](https://github.com/netlify/gotrue/blob/master/api/signup.go#L16)) actually allow you to pass in `{email, password, data}`, setting the metadata upon signup. 

I confirmed this works by monkeypatching it into the client in my project repo, so I forked this repo and edited the code in Github's inline editor for a little proof-of-concept PR here. If you actually want to pull it in I'd be happy to properly clone it and write some tests, but I figured I'd just share this for now. 

Cheers!

