### PR TITLE
Allow signIn() with a refresh_token to enable third party auth on React Native

### DIFF
--- a/src/GoTrueApi.ts
+++ b/src/GoTrueApi.ts
@@ -77,11 +77,7 @@ export default class GoTrueApi {
       if (options.redirectTo) {
         queryString += '&redirect_to=' + options.redirectTo
       }
-      const data = await post(
-        `${this.url}/token${queryString}`,
-        { email, password },
-        { headers }
-      )
+      const data = await post(`${this.url}/token${queryString}`, { email, password }, { headers })
       let session = { ...data }
       if (session.expires_in) session.expires_at = expiresAt(data.expires_in)
       return { data: session, error: null }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -91,6 +91,7 @@ export interface CookieOptions {
 export interface UserCredentials {
   email?: string
   password?: string
+  refreshToken?: string
   // (Optional) The name of the provider.
   provider?: Provider
 }

--- a/test/__snapshots__/clientWithAutoConfirmEnabled.test.ts.snap
+++ b/test/__snapshots__/clientWithAutoConfirmEnabled.test.ts.snap
@@ -96,6 +96,47 @@ Object {
 }
 `;
 
+exports[`signIn() with refreshToken 1`] = `
+Object {
+  "access_token": Any<String>,
+  "expires_at": Any<Number>,
+  "expires_in": Any<Number>,
+  "refresh_token": Any<String>,
+  "token_type": "bearer",
+  "user": Object {
+    "app_metadata": Object {
+      "provider": "email",
+    },
+    "aud": Any<String>,
+    "confirmed_at": Any<String>,
+    "created_at": Any<String>,
+    "email": Any<String>,
+    "id": Any<String>,
+    "last_sign_in_at": Any<String>,
+    "role": "",
+    "updated_at": Any<String>,
+    "user_metadata": Object {},
+  },
+}
+`;
+
+exports[`signIn() with refreshToken 2`] = `
+Object {
+  "app_metadata": Object {
+    "provider": "email",
+  },
+  "aud": Any<String>,
+  "confirmed_at": Any<String>,
+  "created_at": Any<String>,
+  "email": Any<String>,
+  "id": Any<String>,
+  "last_sign_in_at": Any<String>,
+  "role": "",
+  "updated_at": Any<String>,
+  "user_metadata": Object {},
+}
+`;
+
 exports[`signOut 1`] = `
 Object {
   "error": null,

--- a/test/clientWithAutoConfirmEnabled.test.ts
+++ b/test/clientWithAutoConfirmEnabled.test.ts
@@ -17,6 +17,7 @@ let authWithSession = new GoTrueClient({
 
 const email = `client_ac_enabled_${faker.internet.email()}`
 const setSessionEmail = `client_ac_session_${faker.internet.email()}`
+const refreshTokenEmail = `client_refresh_token_signin_${faker.internet.email()}`
 const password = faker.internet.password()
 var access_token: string | null = null
 
@@ -136,6 +137,50 @@ test('signIn()', async () => {
     },
   })
   expect(user?.email).toBe(email)
+})
+test('signIn() with refreshToken', async () => {
+  const { error: initialError, session: initialSession } = await authWithSession.signUp({
+    email: refreshTokenEmail,
+    password,
+  })
+  expect(initialError).toBeNull()
+  expect(initialSession).not.toBeNull()
+
+  const refreshToken = initialSession?.refresh_token
+  const { error, user, session } = await authWithSession.signIn({ refreshToken })
+
+  expect(error).toBeNull()
+  expect(session).toMatchSnapshot({
+    access_token: expect.any(String),
+    refresh_token: expect.any(String),
+    expires_in: expect.any(Number),
+    expires_at: expect.any(Number),
+    user: {
+      id: expect.any(String),
+      email: expect.any(String),
+      aud: expect.any(String),
+      confirmed_at: expect.any(String),
+      last_sign_in_at: expect.any(String),
+      created_at: expect.any(String),
+      updated_at: expect.any(String),
+      app_metadata: {
+        provider: 'email',
+      },
+    },
+  })
+  expect(user).toMatchSnapshot({
+    id: expect.any(String),
+    email: expect.any(String),
+    aud: expect.any(String),
+    confirmed_at: expect.any(String),
+    last_sign_in_at: expect.any(String),
+    created_at: expect.any(String),
+    updated_at: expect.any(String),
+    app_metadata: {
+      provider: 'email',
+    },
+  })
+  expect(user?.email).toBe(refreshTokenEmail)
 })
 
 test('Get user', async () => {


### PR DESCRIPTION
## What kind of change does this PR introduce?

This allows one to call auth.signIn() with a refresh_token to login and retrieve a session. The upside is that this allows one to login on mobile using third party oauth flows on React Native.

## What is the current behavior?

On React Native third party auth flows cannot currently establish a session as the redirect flows are browser based (e.g. `getSessionFromUrl()`). In the issues below a solution of passing access_token & refresh token to `signIn()` was proposed and accepted.

https://github.com/supabase/supabase-js/issues/145
https://github.com/supabase/gotrue/issues/37

## What is the new behaviour?

This allows one to call `signIn()` and get a fresh session using a refresh token. Internally it calls `refreshAccessToken()` which establishes a fresh session but returns the same signature as login with email & password.

```js
  // overly simple example
  startAsync({
    authUrl: `https://MYSUPABASEAPP.supabase.co/auth/v1/authorize?provider=google&redirect_to=${redirectUri}`,
    returnUrl: redirectUri,
  }).then(async (response: any) => {
    if (!response) return;
    const supaResponse = await supabaseClient.auth.signIn({
      refreshToken: response.params?.refresh_token,
    });
  });

```

## Additional Context

An alternative would be to do something similar to `getSessionFromUrl()` as it only calls the gotrue `/user` endpoint and reuses all of the tokens provided in the redirect (including the provider token)