### PR TITLE
feat: allow twitter profile

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,4 +1,4 @@
-export type Provider = 'azure' | 'bitbucket' | 'facebook' | 'github' | 'gitlab' | 'google'
+export type Provider = 'azure' | 'bitbucket' | 'facebook' | 'github' | 'gitlab' | 'google' | 'twitter'
 
 export type AuthChangeEvent =
   | 'SIGNED_IN'


### PR DESCRIPTION
## What kind of change does this PR introduce?

New feature: typescript support for already-existing Twitter social sign in button

## What is the current behavior?

Get TS / ES lint errors and breaks builds in vercel when you use twitter profile in supabase-ui auth component, eg:


```
        <Auth.UserContextProvider supabaseClient={supabase}>
            {/* this is fine: <Auth providers={['github', 'google']} supabaseClient={supabase} /> */}
            <Auth providers={['github', 'google', 'twitter']} supabaseClient={supabase} />
        </Auth.UserContextProvider>
```


## What is the new behavior?

stuff is good
