### PR TITLE
fix: add Apple as Provider in types

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,4 +1,4 @@
-export type Provider = 'azure' | 'bitbucket' | 'facebook' | 'github' | 'gitlab' | 'google' | 'twitter'
+export type Provider = 'azure' | 'bitbucket' | 'facebook' | 'github' | 'gitlab' | 'google' | 'twitter' | 'apple'
 
 export type AuthChangeEvent =
   | 'SIGNED_IN'


### PR DESCRIPTION
• added missing 'apple' provider to type Provider as it's used by Supabase Auth component 