### PR TITLE
fix: supabase/supabase#1915 encode query string parameter values

### DIFF
--- a/src/GoTrueApi.ts
+++ b/src/GoTrueApi.ts
@@ -47,7 +47,7 @@ export default class GoTrueApi {
       let headers = { ...this.headers }
       let queryString = ''
       if (options.redirectTo) {
-        queryString = '?redirect_to=' + options.redirectTo
+        queryString = '?redirect_to=' + encodeURIComponent(options.redirectTo)
       }
       const data = await post(`${this.url}/signup${queryString}`, { email, password }, { headers })
       let session = { ...data }
@@ -75,7 +75,7 @@ export default class GoTrueApi {
       let headers = { ...this.headers }
       let queryString = '?grant_type=password'
       if (options.redirectTo) {
-        queryString += '&redirect_to=' + options.redirectTo
+        queryString += '&redirect_to=' + encodeURIComponent(options.redirectTo)
       }
       const data = await post(`${this.url}/token${queryString}`, { email, password }, { headers })
       let session = { ...data }
@@ -101,7 +101,7 @@ export default class GoTrueApi {
       let headers = { ...this.headers }
       let queryString = ''
       if (options.redirectTo) {
-        queryString += '?redirect_to=' + options.redirectTo
+        queryString += '?redirect_to=' + encodeURIComponent(options.redirectTo)
       }
       const data = await post(`${this.url}/magiclink${queryString}`, { email }, { headers })
       return { data, error: null }
@@ -125,7 +125,7 @@ export default class GoTrueApi {
       let headers = { ...this.headers }
       let queryString = ''
       if (options.redirectTo) {
-        queryString += '?redirect_to=' + options.redirectTo
+        queryString += '?redirect_to=' + encodeURIComponent(options.redirectTo)
       }
       const data = await post(`${this.url}/invite${queryString}`, { email }, { headers })
       return { data, error: null }
@@ -149,7 +149,7 @@ export default class GoTrueApi {
       let headers = { ...this.headers }
       let queryString = ''
       if (options.redirectTo) {
-        queryString += '?redirect_to=' + options.redirectTo
+        queryString += '?redirect_to=' + encodeURIComponent(options.redirectTo)
       }
       const data = await post(`${this.url}/recover${queryString}`, { email }, { headers })
       return { data, error: null }
@@ -199,12 +199,12 @@ export default class GoTrueApi {
       scopes?: string
     }
   ) {
-    let urlParams: string[] = [`provider=${provider}`]
+    let urlParams: string[] = [`provider=${encodeURIComponent(provider)}`]
     if (options?.redirectTo) {
-      urlParams.push(`redirect_to=${options.redirectTo}`)
+      urlParams.push(`redirect_to=${encodeURIComponent(options.redirectTo)}`)
     }
     if (options?.scopes) {
-      urlParams.push(`scopes=${options.scopes}`)
+      urlParams.push(`scopes=${encodeURIComponent(options.scopes)}`)
     }
     return `${this.url}/authorize?${urlParams.join('&')}`
   }

--- a/test/__snapshots__/provider.test.ts.snap
+++ b/test/__snapshots__/provider.test.ts.snap
@@ -4,11 +4,11 @@ exports[`signIn() with Provider 1`] = `"http://localhost:9999/authorize?provider
 
 exports[`signIn() with Provider 2`] = `"google"`;
 
-exports[`signIn() with Provider can append a redirectUrl  1`] = `"http://localhost:9999/authorize?provider=google&redirect_to=https://localhost:9000/welcome"`;
+exports[`signIn() with Provider can append a redirectUrl  1`] = `"http://localhost:9999/authorize?provider=google&redirect_to=https%3A%2F%2Flocalhost%3A9000%2Fwelcome"`;
 
 exports[`signIn() with Provider can append a redirectUrl  2`] = `"google"`;
 
-exports[`signIn() with Provider can append multiple options 1`] = `"http://localhost:9999/authorize?provider=github&redirect_to=https://localhost:9000/welcome&scopes=repo"`;
+exports[`signIn() with Provider can append multiple options 1`] = `"http://localhost:9999/authorize?provider=github&redirect_to=https%3A%2F%2Flocalhost%3A9000%2Fwelcome&scopes=repo"`;
 
 exports[`signIn() with Provider can append multiple options 2`] = `"github"`;
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Encodes query string parameter values.

## What is the current behavior?

supabase/supabase#1915: redirectTo works but cuts the "and" params "&param2=val2&param3=val3".

## What is the new behavior?

`&` and other special characters are encoded.

## Additional context

I considered using [balazsbotond/urlcat](https://github.com/balazsbotond/urlcat) for readability and concision.

E.g.:

```typescript
let urlParams: string[] = [`provider=${encodeURIComponent(provider)}`]
if (options?.redirectTo) {
  urlParams.push(`redirect_to=${encodeURIComponent(options.redirectTo)}`)
}
if (options?.scopes) {
  urlParams.push(`scopes=${encodeURIComponent(options.scopes)}`)
}
return `${this.url}/authorize?${urlParams.join('&')}`
```

Would become:

```typescript
options.provider = provider
return urlcat(this.url, '/authorize', options)
```

However, the increase in bundle size would probably not be worth it.