### PR TITLE
fix: refreshTokenTimer blocks node event loop exit

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -521,5 +521,6 @@ export default class GoTrueClient {
     if (!value || !this.autoRefreshToken) return
 
     this.refreshTokenTimer = setTimeout(() => this._callRefreshToken(), value)
+    if (typeof this.refreshTokenTimer.unref === 'function') this.refreshTokenTimer.unref()
   }
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?
Bug fix

## What is the current behavior?
fixes #99

when `autoRefreshToken` is `true` (the default), the `signIn` method starts a timer that prevents the node event loop from exiting.

## What is the new behavior?
this PR preserves the defaults, while allowing the node process to immediately exit. this change should not functionally affect the previous behavior of the timer in long-running node processes.

in node, we can ensure that the timeout will not require the Node.js event loop to remain active by immediately calling [`unref`](https://nodejs.org/dist/latest-v14.x/docs/api/timers.html#timers_timeout_unref). `unref` should be used judiciously, but it seems to fit well here.

## Additional context
alternatives to consider instead of making this change:
- add docs guidance suggesting `autoRefreshToken: false` when appropriate in node environments
- change the `autoRefreshToken` default to `false` in node environments
- always skip starting the timer in node environments (meaning that `autoRefreshToken` would have no effect in node)
