### PR TITLE
fix: supabase/supabase-js#178 handle JWT expiry <= 60s

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -548,8 +548,12 @@ export default class GoTrueClient {
     this.currentUser = session.user
 
     const expiresAt = session.expires_at
-    const timeNow = Math.round(Date.now() / 1000)
-    if (expiresAt) this._startAutoRefreshToken((expiresAt - timeNow - 60) * 1000)
+    if (expiresAt) {
+      const timeNow = Math.round(Date.now() / 1000)
+      const expiresIn = expiresAt - timeNow
+      const refreshDurationBeforeExpires = expiresIn > 60 ? 60 : 0.5
+      this._startAutoRefreshToken((expiresIn - refreshDurationBeforeExpires) * 1000)
+    }
 
     // Do we need any extra check before persist session
     // access_token or user ?
@@ -576,7 +580,7 @@ export default class GoTrueClient {
    */
   private _startAutoRefreshToken(value: number) {
     if (this.refreshTokenTimer) clearTimeout(this.refreshTokenTimer)
-    if (!value || !this.autoRefreshToken) return
+    if (value <= 0 || !this.autoRefreshToken) return
 
     this.refreshTokenTimer = setTimeout(() => this._callRefreshToken(), value)
   }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Handles JWT expiry <= 60s correctly.

## What is the current behavior?

supabase/supabase-js#178: Refresh token doesn't update when JWT expiry is set to 60, constantly updates when JWT expiry is set to less than 60 since `expiresAt - timeNow - 60` is negative.

## What is the new behavior?

When JWT expiry is set to more than 60, current behavior remains to refresh 60s before expiry. When JWT expiry is set to 60 or less, new behavior is to refresh 0.5s before expiry.

## Additional context

0.5s is chosen to support JWT expiry of 1s, even though that should be an edge case. That should usually still be enough time to reach the server before expiry.
