### PR TITLE
fix: added 'twitch' to Providers

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,4 +1,4 @@
-export type Provider = 'azure' | 'bitbucket' | 'facebook' | 'github' | 'gitlab' | 'google' | 'twitter' | 'apple' | 'discord'
+export type Provider = 'azure' | 'bitbucket' | 'facebook' | 'github' | 'gitlab' | 'google' | 'twitter' | 'apple' | 'discord' | 'twitch'
 
 export type AuthChangeEvent =
   | 'SIGNED_IN'


### PR DESCRIPTION
Twitch was deployed as a provider but did not exist in the Provider type array

