### PR TITLE
feat: add admin createUser api method

### DIFF
--- a/src/GoTrueApi.ts
+++ b/src/GoTrueApi.ts
@@ -250,6 +250,25 @@ export default class GoTrueApi {
     return headers
   }
 
+    /**
+   * Creates a new user.
+   * @param jwt A valid JWT. Must be a full-access API key (e.g. service_role key).
+   * @param attributes The data you want to create the user with.
+   */
+     async createUser(
+      jwt: string,
+      attributes: UserAttributes
+    ): Promise<{ data: null; error: Error  } | { data: User; error:  null }> {
+      try {
+        const data: any = await post(`${this.url}/admin/users`, attributes, {
+          headers: this._createRequestHeaders(jwt),
+        })
+        return {  data, error: null }
+      } catch (error) {
+        return { data: null, error }
+      }
+    }
+
   /**
    * Removes a logged-in session.
    * @param jwt A valid, logged-in JWT.


### PR DESCRIPTION
Related to #90

## What kind of change does this PR introduce?
Defines a wrapper around the POST /admin/users API endpoint.


## What is the current behavior?
You can create new users in Node.js (server-side admin environment):

## What is the new behavior?

```
import { GoTrueClient } from '@supabase/gotrue-js'

const GOTRUE_URL = 'http://localhost:9999'

const auth = new GoTrueApi({ url: GOTRUE_URL })
const { data, error } = await auth.createUser(jwt, { email: 'john@example.com' });
```

## Additional context
All this does is build off the solution in #97 by:
- Changing the response typing to better indicate success vs failure (similar to how the response types are defined in postgrest-js)
- Adds basic tests