### PR TITLE
Access localStorage lazily to avoid DOMExceptions in constrained envs when `localStorage` is provided using options

### DIFF
--- a/example/expo/App.tsx
+++ b/example/expo/App.tsx
@@ -7,12 +7,11 @@ import AsyncStorage from '@react-native-community/async-storage'
 import Button from './components/Button'
 import TextField from './components/TextField'
 
-const auth = new GoTrueClient({ localStorage: AsyncStorage as any })
+const auth = new GoTrueClient({ localStorage: AsyncStorage })
 
 export default function App() {
   const [email, setEmail] = React.useState('')
   const [password, setPassword] = React.useState('')
-
 
   return (
     <View style={styles.container}>

--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -1,5 +1,5 @@
 import GoTrueApi from './GoTrueApi'
-import { isBrowser, getParameterByName, uuid, LocalStorage } from './lib/helpers'
+import { isBrowser, getParameterByName, uuid } from './lib/helpers'
 import { GOTRUE_URL, DEFAULT_HEADERS, STORAGE_KEY } from './lib/constants'
 import {
   Session,
@@ -20,10 +20,21 @@ const DEFAULT_OPTIONS = {
   url: GOTRUE_URL,
   autoRefreshToken: true,
   persistSession: true,
-  localStorage: globalThis.localStorage,
   detectSessionInUrl: true,
   headers: DEFAULT_HEADERS,
 }
+
+type AnyFunction = (...args: any[]) => any
+type MaybePromisify<T> = T | Promise<T>
+
+type PromisifyMethods<T> = {
+  [K in keyof T]: T[K] extends AnyFunction
+    ? (...args: Parameters<T[K]>) => MaybePromisify<ReturnType<T[K]>>
+    : T[K]
+}
+
+type SupportedStorage = PromisifyMethods<Pick<Storage, 'getItem' | 'setItem' | 'removeItem'>>
+
 export default class GoTrueClient {
   /**
    * Namespace for the GoTrue API methods.
@@ -41,7 +52,7 @@ export default class GoTrueClient {
 
   protected autoRefreshToken: boolean
   protected persistSession: boolean
-  protected localStorage: Storage
+  protected localStorage: SupportedStorage
   protected stateChangeEmitters: Map<string, Subscription> = new Map()
   protected refreshTokenTimer?: ReturnType<typeof setTimeout>
 
@@ -60,7 +71,7 @@ export default class GoTrueClient {
     detectSessionInUrl?: boolean
     autoRefreshToken?: boolean
     persistSession?: boolean
-    localStorage?: Storage
+    localStorage?: SupportedStorage
     cookieOptions?: CookieOptions
   }) {
     const settings = { ...DEFAULT_OPTIONS, ...options }
@@ -68,7 +79,7 @@ export default class GoTrueClient {
     this.currentSession = null
     this.autoRefreshToken = settings.autoRefreshToken
     this.persistSession = settings.persistSession
-    this.localStorage = new LocalStorage(settings.localStorage)
+    this.localStorage = settings.localStorage || globalThis.localStorage
     this.api = new GoTrueApi({
       url: settings.url,
       headers: settings.headers,
@@ -108,7 +119,7 @@ export default class GoTrueClient {
   }> {
     try {
       this._removeSession()
-      
+
       const { data, error } =
         phone && password
           ? await this.api.signUpWithPhone(phone!, password!)

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -22,27 +22,3 @@ export function getParameterByName(name: string, url?: string) {
   if (!results[2]) return ''
   return decodeURIComponent(results[2].replace(/\+/g, ' '))
 }
-
-export class LocalStorage implements Storage {
-  localStorage: Storage;
-  [name: string]: any
-  length!: number
-  constructor(localStorage: Storage) {
-    this.localStorage = localStorage || globalThis.localStorage
-  }
-  clear(): void {
-    return this.localStorage.clear()
-  }
-  key(index: number): string | null {
-    return this.localStorage.key(index)
-  }
-  setItem(key: string, value: any): void {
-    return this.localStorage.setItem(key, value)
-  }
-  getItem(key: string): string | null {
-    return this.localStorage.getItem(key)
-  }
-  removeItem(key: string): void {
-    return this.localStorage.removeItem(key)
-  }
-}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

in 3rd party iframes in the incognito mode accessing `localStorage` might throw:
> Uncaught DOMException: Failed to read the 'localStorage' property from 'Window': Access is denied for this document
<img width="541" alt="Screenshot 2021-08-05 at 14 40 22" src="https://user-images.githubusercontent.com/9800850/128356700-82c5b6e4-334a-4b98-8929-57d202f9fdb2.png">

## What is the new behavior?

Accessing `localStorage` has been made **lazy** (has been removed from the synchronous initialization path of the module to the constructor of one of the classes). This only helps when one provides `localStorage` through options (which will benefit me because I can do that to avoid that unsafe access). You could try to improve the situation for all users as well but you would have to figure out what would be the most appropriate solution for your use case.

## Additional context

I've also refactored the code related to `localStorage` a little bit:
1. I'm creating a custom type for what you are actually using - when I provide a custom `localStorage` using options I don't want to satisfy the whole `Storage` interface because I have no use for it. Ideally, I'd only have to provide what you actually need here. Right now I'm casting with `as Storage` but that's unsafe (if you start using something in the future that I have not covered in my implementation). This also actually starts accepting `AsyncStorage` without the need to cast it to `any` and removes TS warnings that `await` does not have any effect on the calls to `this.localStorage`. The end result is that this is more type-safe and correct
2. In the process I've also removed a custom `LocalStorage` class. The only thing that it was doing was to proxy calls to the internal `this.localStorage` (the provided one or the DOM one) without actually doing anything else - this was introducing an additional function layer for all the calls to the `localStorage`. This ain't that big of a problem on its own but I found this code to be not necessary and its presence made my type-changes more complicated. I would also have to drop half of its implementation anyway because my type changes focus on using only the required `localStorage` methods and this class was over-implementing the `Storage` interface