### PR TITLE
fix docs links

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ const GOTRUE_URL = 'http://localhost:9999'
 const auth = new GoTrueClient({ url: GOTRUE_URL })
 ```
 
-- `signUp()`: https://supabase.io/docs/gotrue/client/signup
-- `signIn()`: https://supabase.io/docs/gotrue/client/signin
-- `signOut()`: https://supabase.io/docs/gotrue/client/signout
+- `signUp()`: https://supabase.io/docs/reference/javascript/auth-signup
+- `signIn()`: https://supabase.io/docs/reference/javascript/auth-signin
+- `signOut()`: https://supabase.io/docs/reference/javascript/auth-signout
 
 ## Sponsors
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

- fix https://github.com/supabase/gotrue-js/issues/121

## Additional context

The new links aren't entirely accurate, becase they show how to use gotrue-js through supabase-js.

We could also point it to the TS Doc if prefered: https://supabase.github.io/gotrue-js/classes/gotrueclient.html#signin
