### PR TITLE
fix: make supabase.auth.onAuthStateChange work across browser windows

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -85,6 +85,20 @@ export default class GoTrueClient {
     } catch (error) {
       console.log('Error getting session from URL.')
     }
+    if (isBrowser()) {
+      window.onstorage = (e: StorageEvent) => {
+        if (e.key === 'supabase.auth.token') {
+          const newSession = JSON.parse(String(e.newValue))
+          if (newSession?.currentSession?.access_token) {
+            this._recoverAndRefresh()
+            this._notifyAllSubscribers('SIGNED_IN')
+          } else {
+            this._removeSession()
+            this._notifyAllSubscribers('SIGNED_OUT')
+          }
+        }
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix: ensure onAuthStateChange works across multiple browser windows 

## What is the current behavior?

Addresses [#2739](https://github.com/supabase/supabase/issues/2739)  - "onAuthStateChange does not catch auth state changes across multiple windows"

## What is the new behavior?

![2021-08-27_16-13-41 (1)](https://user-images.githubusercontent.com/15890505/131141474-ae6b6968-2904-4d84-bf6e-d76c0e4d5d69.gif)
