### PR TITLE
passthrough user metadata on sign up

### DIFF
--- a/src/GoTrueApi.ts
+++ b/src/GoTrueApi.ts
@@ -32,6 +32,7 @@ export default class GoTrueApi {
    * @param email The email address of the user.
    * @param password The password of the user.
    * @param redirectTo A URL or mobile address to send the user to after they are confirmed.
+   * @param data Optional user metadata.
    *
    * @returns A logged-in session if the server has "autoconfirm" ON
    * @returns A user if the server has "autoconfirm" OFF
@@ -41,6 +42,7 @@ export default class GoTrueApi {
     password: string,
     options: {
       redirectTo?: string
+      data?: object
     } = {}
   ): Promise<{ data: Session | User | null; error: Error | null }> {
     try {
@@ -49,7 +51,11 @@ export default class GoTrueApi {
       if (options.redirectTo) {
         queryString = '?redirect_to=' + encodeURIComponent(options.redirectTo)
       }
-      const data = await post(`${this.url}/signup${queryString}`, { email, password }, { headers })
+      const data = await post(
+        `${this.url}/signup${queryString}`,
+        { email, password, data: options.data },
+        { headers }
+      )
       let session = { ...data }
       if (session.expires_in) session.expires_at = expiresAt(data.expires_in)
       return { data: session, error: null }
@@ -90,14 +96,22 @@ export default class GoTrueApi {
    * Signs up a new user using their phone number and a password.
    * @param phone The phone number of the user.
    * @param password The password of the user.
+   * @param data Optional user metadata.
    */
   async signUpWithPhone(
     phone: string,
-    password: string
+    password: string,
+    options: {
+      data?: object
+    } = {}
   ): Promise<{ data: Session | User | null; error: Error | null }> {
     try {
       let headers = { ...this.headers }
-      const data = await post(`${this.url}/signup`, { phone, password }, { headers })
+      const data = await post(
+        `${this.url}/signup`,
+        { phone, password, data: options.data },
+        { headers }
+      )
       let session = { ...data }
       if (session.expires_in) session.expires_at = expiresAt(data.expires_in)
       return { data: session, error: null }
@@ -195,11 +209,13 @@ export default class GoTrueApi {
    * Sends an invite link to an email address.
    * @param email The email address of the user.
    * @param redirectTo A URL or mobile address to send the user to after they are confirmed.
+   * @param data Optional user metadata
    */
   async inviteUserByEmail(
     email: string,
     options: {
       redirectTo?: string
+      data?: object
     } = {}
   ): Promise<{ data: User | null; error: Error | null }> {
     try {
@@ -208,7 +224,11 @@ export default class GoTrueApi {
       if (options.redirectTo) {
         queryString += '?redirect_to=' + encodeURIComponent(options.redirectTo)
       }
-      const data = await post(`${this.url}/invite${queryString}`, { email }, { headers })
+      const data = await post(
+        `${this.url}/invite${queryString}`,
+        { email, data: options.data },
+        { headers }
+      )
       return { data, error: null }
     } catch (error) {
       return { data: null, error }
@@ -429,7 +449,7 @@ export default class GoTrueApi {
     email: string,
     options: {
       password?: string
-      data?: any
+      data?: object
       redirectTo?: string
     } = {}
   ): Promise<{ data: Session | User | null; error: Error | null }> {

--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -94,11 +94,13 @@ export default class GoTrueClient {
    * @param password The user's password.
    * @param phone The user's phone number.
    * @param redirectTo A URL or mobile address to send the user to after they are confirmed.
+   * @param data Optional user metadata.
    */
   async signUp(
     { email, password, phone }: UserCredentials,
     options: {
       redirectTo?: string
+      data?: object
     } = {}
   ): Promise<{
     user: User | null
@@ -111,9 +113,12 @@ export default class GoTrueClient {
 
       const { data, error } =
         phone && password
-          ? await this.api.signUpWithPhone(phone!, password!)
+          ? await this.api.signUpWithPhone(phone!, password!, {
+              data: options.data,
+            })
           : await this.api.signUpWithEmail(email!, password!, {
               redirectTo: options.redirectTo,
+              data: options.data,
             })
 
       if (error) {

--- a/test/apiWithAutoConfirmDisabled.test.ts
+++ b/test/apiWithAutoConfirmDisabled.test.ts
@@ -16,6 +16,7 @@ const password = faker.internet.password()
 test('signUpWithEmail()', async () => {
   let { error, data } = await api.signUpWithEmail(email, password, {
     redirectTo: 'https://localhost:9999/welcome',
+    data: { status: 'alpha' },
   })
   expect(error).toBeNull()
   expect(data).toMatchObject({
@@ -29,6 +30,9 @@ test('signUpWithEmail()', async () => {
     updated_at: expect.any(String),
     app_metadata: {
       provider: 'email',
+    },
+    user_metadata: {
+      status: 'alpha',
     },
   })
 })
@@ -54,6 +58,9 @@ test('signUpWithGenerateConfirmationLink()', async () => {
     updated_at: expect.any(String),
     app_metadata: {
       provider: 'email',
+    },
+    user_metadata: {
+      status: 'alpha',
     },
   })
 })

--- a/test/clientWithAutoConfirmDisabled.test.ts
+++ b/test/clientWithAutoConfirmDisabled.test.ts
@@ -16,10 +16,13 @@ const testTwilio = false
 const phone = faker.phone.phoneNumber() // set test number here
 
 test('signUp() with email and password', async () => {
-  let { error, user, session } = await auth.signUp({
-    email,
-    password,
-  })
+  let { error, user, session } = await auth.signUp(
+    {
+      email,
+      password,
+    },
+    { data: { status: 'alpha' } }
+  )
   expect(error).toBeNull()
   expect(session).toBeNull()
   expect(user).toMatchObject({
@@ -32,6 +35,9 @@ test('signUp() with email and password', async () => {
     updated_at: expect.any(String),
     app_metadata: {
       provider: 'email',
+    },
+    user_metadata: {
+      status: 'alpha',
     },
   })
   expect(user?.email_confirmed_at).toBeUndefined()
@@ -70,10 +76,15 @@ test('signIn() with the wrong password', async () => {
 
 if (testTwilio) {
   test('signUp() with phone and password', async () => {
-    let { error, user, session } = await auth.signUp({
-      phone,
-      password,
-    })
+    let { error, user, session } = await auth.signUp(
+      {
+        phone,
+        password,
+      },
+      {
+        data: { status: 'alpha' },
+      }
+    )
     expect(error).toBeNull()
     expect(session).toBeNull()
     expect(user).toMatchObject({
@@ -86,6 +97,9 @@ if (testTwilio) {
       updated_at: expect.any(String),
       app_metadata: {
         provider: 'phone',
+      },
+      user_metadata: {
+        status: 'alpha',
       },
     })
     expect(user?.phone_confirmed_at).toBeUndefined()

--- a/test/clientWithAutoConfirmEnabled.test.ts
+++ b/test/clientWithAutoConfirmEnabled.test.ts
@@ -22,10 +22,13 @@ const password = faker.internet.password()
 var access_token: string | null = null
 
 test('signUp()', async () => {
-  let { error, user, session } = await auth.signUp({
-    email,
-    password,
-  })
+  let { error, user, session } = await auth.signUp(
+    {
+      email,
+      password,
+    },
+    { data: { status: 'alpha' } }
+  )
   access_token = session?.access_token || null
   expect(error).toBeNull()
   expect(error).toBeNull()
@@ -46,6 +49,9 @@ test('signUp()', async () => {
       updated_at: expect.any(String),
       app_metadata: {
         provider: 'email',
+      },
+      user_metadata: {
+        status: 'alpha',
       },
     },
   })


### PR DESCRIPTION
## What kind of change does this PR introduce?

Lets you add metadata when signing up a user instead of having to sign up then update.

## What is the current behavior?

Adding arbitrary data to the auth.user table is only possible via the update call.

## What is the new behavior?

You can optionally pass in user_metadata in the options object to add the metadata upon signup.

## Additional context

This PR expands on the proof of concept provided by @johncomposed in #91
