### PR TITLE
fix: semantic release failed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "cross-fetch": "^3.0.6"
+        "cross-fetch": "^3.0.6",
+        "save-dev": "*"
       },
       "devDependencies": {
         "@types/faker": "^5.1.6",
@@ -22,6 +23,7 @@
         "npm-run-all": "^4.1.5",
         "prettier": "^2.0.5",
         "rimraf": "^3.0.2",
+        "semantic-release-plugin-update-version-in-files": "^1.1.0",
         "ts-jest": "^26.3.0",
         "typedoc": "^0.19.1",
         "typescript": "^4.0.2"
@@ -6905,6 +6907,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/save-dev": {
+      "version": "0.0.1-security",
+      "resolved": "https://registry.npmjs.org/save-dev/-/save-dev-0.0.1-security.tgz",
+      "integrity": "sha512-k6knZTDNK8PKKbIqnvxiOveJinuw2LcQjqDoaorZWP9M5AR2EPsnpDeSbeoZZ0pHr5ze1uoaKdK8NBGQrJ34Uw=="
+    },
     "node_modules/saxes": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz",
@@ -6915,6 +6922,16 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/semantic-release-plugin-update-version-in-files": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/semantic-release-plugin-update-version-in-files/-/semantic-release-plugin-update-version-in-files-1.1.0.tgz",
+      "integrity": "sha512-OWBrved3Rr0w3YP4iID81MhG9qhGrG+XtxdO9VMhKJ9qte3yBdMz5cSxDiPE/uhnGJQF00fqQetY3yhHFGabWw==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.1",
+        "glob": "^7.1.3"
       }
     },
     "node_modules/semver": {
@@ -13647,6 +13664,11 @@
         }
       }
     },
+    "save-dev": {
+      "version": "0.0.1-security",
+      "resolved": "https://registry.npmjs.org/save-dev/-/save-dev-0.0.1-security.tgz",
+      "integrity": "sha512-k6knZTDNK8PKKbIqnvxiOveJinuw2LcQjqDoaorZWP9M5AR2EPsnpDeSbeoZZ0pHr5ze1uoaKdK8NBGQrJ34Uw=="
+    },
     "saxes": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz",
@@ -13654,6 +13676,16 @@
       "dev": true,
       "requires": {
         "xmlchars": "^2.2.0"
+      }
+    },
+    "semantic-release-plugin-update-version-in-files": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/semantic-release-plugin-update-version-in-files/-/semantic-release-plugin-update-version-in-files-1.1.0.tgz",
+      "integrity": "sha512-OWBrved3Rr0w3YP4iID81MhG9qhGrG+XtxdO9VMhKJ9qte3yBdMz5cSxDiPE/uhnGJQF00fqQetY3yhHFGabWw==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.1",
+        "glob": "^7.1.3"
       }
     },
     "semver": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "cross-fetch": "^3.0.6",
-        "save-dev": "*"
+        "cross-fetch": "^3.0.6"
       },
       "devDependencies": {
         "@types/faker": "^5.1.6",
@@ -6907,11 +6906,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/save-dev": {
-      "version": "0.0.1-security",
-      "resolved": "https://registry.npmjs.org/save-dev/-/save-dev-0.0.1-security.tgz",
-      "integrity": "sha512-k6knZTDNK8PKKbIqnvxiOveJinuw2LcQjqDoaorZWP9M5AR2EPsnpDeSbeoZZ0pHr5ze1uoaKdK8NBGQrJ34Uw=="
-    },
     "node_modules/saxes": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz",
@@ -13663,11 +13657,6 @@
           }
         }
       }
-    },
-    "save-dev": {
-      "version": "0.0.1-security",
-      "resolved": "https://registry.npmjs.org/save-dev/-/save-dev-0.0.1-security.tgz",
-      "integrity": "sha512-k6knZTDNK8PKKbIqnvxiOveJinuw2LcQjqDoaorZWP9M5AR2EPsnpDeSbeoZZ0pHr5ze1uoaKdK8NBGQrJ34Uw=="
     },
     "saxes": {
       "version": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "docs:json": "typedoc --json docs/spec.json --mode modules --includeDeclarations --excludeExternals"
   },
   "dependencies": {
-    "cross-fetch": "^3.0.6"
+    "cross-fetch": "^3.0.6",
+    "save-dev": "*"
   },
   "devDependencies": {
     "@types/faker": "^5.1.6",
@@ -44,6 +45,7 @@
     "npm-run-all": "^4.1.5",
     "prettier": "^2.0.5",
     "rimraf": "^3.0.2",
+    "semantic-release-plugin-update-version-in-files": "^1.1.0",
     "ts-jest": "^26.3.0",
     "typedoc": "^0.19.1",
     "typescript": "^4.0.2"

--- a/package.json
+++ b/package.json
@@ -31,8 +31,7 @@
     "docs:json": "typedoc --json docs/spec.json --mode modules --includeDeclarations --excludeExternals"
   },
   "dependencies": {
-    "cross-fetch": "^3.0.6",
-    "save-dev": "*"
+    "cross-fetch": "^3.0.6"
   },
   "devDependencies": {
     "@types/faker": "^5.1.6",


### PR DESCRIPTION
## What kind of change does this PR introduce?

fix #135 

## What is the current behavior?

```
[9:47:03 AM] [semantic-release] › ℹ  Running semantic-release version 17.4.7
[9:47:03 AM] [semantic-release] › ✖  An error occurred while running semantic-release: Error: Cannot find module 'semantic-release-plugin-update-version-in-files'
Require stack:
- /home/runner/work/gotrue-js/gotrue-js/noop.js
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:815:15)
    at resolveFileName (/home/runner/.npm/_npx/1729/lib/node_modules/semantic-release/node_modules/resolve-from/index.js:29:39)
    at resolveFrom (/home/runner/.npm/_npx/1729/lib/node_modules/semantic-release/node_modules/resolve-from/index.js:43:9)
    at module.exports (/home/runner/.npm/_npx/1729/lib/node_modules/semantic-release/node_modules/resolve-from/index.js:46:47)
    at loadPlugin (/home/runner/.npm/_npx/1729/lib/node_modules/semantic-release/lib/plugins/utils.js:51:82)
    at /home/runner/.npm/_npx/1729/lib/node_modules/semantic-release/lib/plugins/index.js:17:37
    at Array.reduce (<anonymous>)
    at module.exports (/home/runner/.npm/_npx/1729/lib/node_modules/semantic-release/lib/plugins/index.js:14:34)
    at module.exports (/home/runner/.npm/_npx/1729/lib/node_modules/semantic-release/lib/get-config.js:84:35)
    at async module.exports (/home/runner/.npm/_npx/1729/lib/node_modules/semantic-release/index.js:257:32) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [ '/home/runner/work/gotrue-js/gotrue-js/noop.js' ]
}
```

## What is the new behavior?

add `semantic-release-plugin-update-version-in-files` into devDependencies
