### PR TITLE
docs: updated deleteUser documentation about service key on server side

### DIFF
--- a/src/GoTrueApi.ts
+++ b/src/GoTrueApi.ts
@@ -345,7 +345,10 @@ export default class GoTrueApi {
   }
 
   /**
-   * Delete an user.
+   * Delete a user. Requires a `service_role` key.
+   *
+   * This function should only be called on a server. Never expose your `service_role` key in the browser.
+   *
    * @param uid The user uid you want to remove.
    * @param jwt A valid JWT. Must be a full-access API key (e.g. service_role key).
    */


### PR DESCRIPTION
## What kind of change does this PR introduce?
Updates [delete user](https://supabase.io/docs/reference/javascript/delete-user) documentation page to emphasize about the service key should be used only on the server side.

## What is the current behavior?
No mention of service key.

[Linked Issue](https://github.com/supabase/supabase/issues/3018)

## What is the new behavior?
The docs are updated to emphasize that the service key should only be used on the server side.

