### PR TITLE
feat: add cookie options to the GoTrueClient constructor options's jsdocs params

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -64,6 +64,7 @@ export default class GoTrueClient {
    * @param options.autoRefreshToken Set to "true" if you want to automatically refresh the token before expiring.
    * @param options.persistSession Set to "true" if you want to automatically save the user session into local storage.
    * @param options.localStorage
+   * @param options.cookieOptions
    */
   constructor(options: {
     url?: string


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update

## What is the current behavior?

Jsdocs params for `cookieOptions` is missing in the GoTrueClient construction options. [Please check here.](https://github.com/supabase/gotrue-js/blob/02c16c0fbdcb9e4c409304769ec29cb58efa2f45/src/GoTrueClient.ts#L66)

## What is the new behavior?

jsdocs params for `cookieOptions` is added to the constructor options `jsdocs params`.
