### PR TITLE
feat: replace async storage with secure store

### DIFF
--- a/example/expo/App.tsx
+++ b/example/expo/App.tsx
@@ -3,11 +3,11 @@ import React from 'react'
 import { StyleSheet, Text, View } from 'react-native'
 import { GoTrueClient } from '@supabase/gotrue-js'
 import { Styles } from './lib/Constants'
-import AsyncStorage from '@react-native-community/async-storage'
+import * as SecureStore from 'expo-secure-store';
 import Button from './components/Button'
 import TextField from './components/TextField'
 
-const auth = new GoTrueClient({ localStorage: AsyncStorage })
+const auth = new GoTrueClient({ localStorage: SecureStore })
 
 export default function App() {
   const [email, setEmail] = React.useState('')

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "cross-fetch": "^3.0.6"
+        "cross-fetch": "^3.0.6",
+        "expo-secure-store": "^10.2.0"
       },
       "devDependencies": {
         "@types/faker": "^5.1.6",
@@ -848,6 +849,7 @@
         "jest-resolve": "^26.5.2",
         "jest-util": "^26.5.2",
         "jest-worker": "^26.5.0",
+        "node-notifier": "^8.0.0",
         "slash": "^3.0.0",
         "source-map": "^0.6.0",
         "string-length": "^4.0.1",
@@ -2303,7 +2305,8 @@
         "esprima": "^4.0.1",
         "estraverse": "^4.2.0",
         "esutils": "^2.0.2",
-        "optionator": "^0.8.1"
+        "optionator": "^0.8.1",
+        "source-map": "~0.6.1"
       },
       "bin": {
         "escodegen": "bin/escodegen.js",
@@ -2503,6 +2506,11 @@
       "engines": {
         "node": ">= 10.14.2"
       }
+    },
+    "node_modules/expo-secure-store": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/expo-secure-store/-/expo-secure-store-10.2.0.tgz",
+      "integrity": "sha512-yNahMY3qzEotAYdsE02ps4yGfDay2twasHfsI/7gJB9SrwXYFx5bJuCDk8uTo8jsm6psvDjO+9VMM2DSPHik2A=="
     },
     "node_modules/extend": {
       "version": "3.0.2",
@@ -2899,6 +2907,7 @@
         "minimist": "^1.2.5",
         "neo-async": "^2.6.0",
         "source-map": "^0.6.1",
+        "uglify-js": "^3.1.4",
         "wordwrap": "^1.0.0"
       },
       "bin": {
@@ -4054,6 +4063,7 @@
         "@types/node": "*",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
+        "fsevents": "^2.1.2",
         "graceful-fs": "^4.2.4",
         "jest-regex-util": "^26.0.0",
         "jest-serializer": "^26.5.0",
@@ -5353,6 +5363,7 @@
       "integrity": "sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==",
       "dev": true,
       "dependencies": {
+        "graceful-fs": "^4.1.6",
         "universalify": "^1.0.0"
       },
       "optionalDependencies": {
@@ -10215,6 +10226,11 @@
           "dev": true
         }
       }
+    },
+    "expo-secure-store": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/expo-secure-store/-/expo-secure-store-10.2.0.tgz",
+      "integrity": "sha512-yNahMY3qzEotAYdsE02ps4yGfDay2twasHfsI/7gJB9SrwXYFx5bJuCDk8uTo8jsm6psvDjO+9VMM2DSPHik2A=="
     },
     "extend": {
       "version": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "docs:json": "typedoc --json docs/spec.json --mode modules --includeDeclarations --excludeExternals"
   },
   "dependencies": {
-    "cross-fetch": "^3.0.6"
+    "cross-fetch": "^3.0.6",
+    "expo-secure-store": "^10.2.0"
   },
   "devDependencies": {
     "@types/faker": "^5.1.6",


### PR DESCRIPTION
## What kind of change does this PR introduce?

Replaces `@react-native-community/async-storage` with `expo-secure-store`.

## What is the current behavior?

Sensitive user data such as the access token are stored in Async Storage, which is an unencrypted key-value store for React Native.

## What is the new behavior?

`Expo-secure-store` is an encrypted key-value store.

It uses Keychain on iOS and EncryptedSharedPreferences on Android to encrypt data.

#### iOS - Keychain Services
Keychain Services allows you to securely store small chunks of sensitive info for the user. This is an ideal place to store certificates, tokens, passwords, and any other sensitive information that doesn’t belong in Async Storage.

#### Android - Secure Shared Preferences
Shared Preferences is the Android equivalent for a persistent key-value data store. Data in Shared Preferences is not encrypted by default, but Encrypted Shared Preferences wraps the Shared Preferences class for Android, and automatically encrypts keys and values.

## Additional context

See the official [React Native docs](https://reactnative.dev/docs/security) on storing sensitive user data.
