### PR TITLE
Add initial event to onAuthStateChange

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -11,6 +11,7 @@ export type Provider =
   | 'twitch'
 
 export type AuthChangeEvent =
+  | 'INITIAL'
   | 'SIGNED_IN'
   | 'SIGNED_OUT'
   | 'USER_UPDATED'


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes supabase/gotrue-js#326

## What is the current behavior?

There is no event fired unless a sign in occurs, but that is sometimes delayed. So there is no way to know if the user is signed in or not right when the page loads

## What is the new behavior?

There is an `INITIAL` event fired after the library is finished loading and checking for a logged in user.
