### PR TITLE
fix: Updates failing test for signup twice with the same email 

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "build:module": "tsc -p tsconfig.module.json",
     "test": "run-s test:clean test:infra test:suite test:clean",
     "test:suite": "jest --runInBand",
-    "test:infra": "cd infra && docker-compose down && docker-compose pull && docker-compose up -d && sleep 3",
+    "test:infra": "cd infra && docker-compose down && docker-compose pull && docker-compose up -d && sleep 10",
     "test:clean": "cd infra && docker-compose down --remove-orphans",
     "docs": "typedoc --mode file --target ES6 --theme minimal",
     "docs:json": "typedoc --json docs/spec.json --mode modules --includeDeclarations --excludeExternals"

--- a/test/README.md
+++ b/test/README.md
@@ -4,7 +4,6 @@
 
 - Docker & docker compose
 
-
 ### Basic testing
 
 Run all tests:
@@ -13,6 +12,10 @@ Run all tests:
 npm run test
 ```
 
+> Note: If tests fail due to connection issues, your tests may be running too soon and the infra is not yet ready.
+> If that's the case, adjust the `sleep 10` duration in:
+> `"test:infra": "cd infra && docker-compose down && docker-compose pull && docker-compose up -d && sleep 10",`
+> to a value that works for your system setup.
 
 ### Advanced
 
@@ -30,4 +33,4 @@ You can now open the mock mail server on `http://localhost:9000`
 npm run test:suite
 ```
 
-All emails will appear in the mock mail server. 
+All emails will appear in the mock mail server.

--- a/test/clientWithAutoConfirmEnabled.test.ts
+++ b/test/clientWithAutoConfirmEnabled.test.ts
@@ -83,14 +83,29 @@ test('setSession should return no error', async () => {
   expect(user?.user_metadata).toStrictEqual({ hello: 'world' })
 })
 
-test('signUp() the same user twice should throw an error', async () => {
-  const { error, data, user } = await auth.signUp({
-    email,
-    password,
+test('signUp() the same user twice should not share email already registered message', async () => {
+  // let's sign up twice with a specific user so we can run this test individually
+  // and not rely on prior tests to have signed up the same user email
+  const emailSignupTwice = `client_ac_enabled_${faker.internet.email().toLowerCase()}`
+  const passwordSignupTwice = faker.internet.password()
+
+  await auth.signUp({
+    email: emailSignupTwice,
+    password: passwordSignupTwice,
   })
-  expect(error?.message).toBe('A user with this email address has already been registered')
+
+  const { error, data, user } = await auth.signUp({
+    email: emailSignupTwice,
+    password: passwordSignupTwice,
+  })
+
   expect(data).toBeNull()
   expect(user).toBeNull()
+
+  // the error message thanks the user, asks them to check their email for confirmation
+  // but doesn't confirm that the email exists
+  // that is -- the message is the same for new and existing users
+  expect(error?.message).toMatch(/^Thanks for registering/)
 })
 
 test('setAuth() should set the Auth headers on a new client', async () => {


### PR DESCRIPTION
## What kind of change does this PR introduce?

The test for `signUp() the same user twice` was failing because the message was changed in GoTrue to prevent leaking information about the user -- that a user with this email already exists. 

![image](https://user-images.githubusercontent.com/1051633/138490338-e23d86c2-36b4-422c-8967-915db4a5f554.png)

With this message, a bad actor could try an email and see if they were or were not a subscriber of this server or used the app.

That the message is the same for new sign ups and subsequent ones helps reduce that risk.

## What is the current behavior? / What is the new behavior?

Actually message is a "Thanks" for registering message and a note to check their email.

Therefore, this test checks for the expected current error message.

## Additional context

See: https://github.com/supabase/gotrue/issues/235
