### PR TITLE
fix: use `location.assign` instead of `href`

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -532,7 +532,7 @@ export default class GoTrueClient {
     try {
       // try to open on the browser
       if (isBrowser()) {
-        window.location.href = url
+        window.location.assign(url)
       }
       return { provider, url, data: null, session: null, user: null, error: null }
     } catch (error) {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature (and a bug fix kinda; fixes #155).

## What is the current behavior?

See #155.

## What is the new behavior?

Nothing different; Supabase simply uses `location.assign(url)` instead of `location.href = url`.
