### PR TITLE
feat: allow providing custom fetch implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,22 @@ const auth = new GoTrueClient({ url: GOTRUE_URL })
 - `signIn()`: https://supabase.io/docs/reference/javascript/auth-signin
 - `signOut()`: https://supabase.io/docs/reference/javascript/auth-signout
 
+### Custom `fetch` implementation
+
+`gotrue-js` uses the [`cross-fetch`](https://www.npmjs.com/package/cross-fetch) library to make HTTP requests, but an alternative `fetch` implementation can be provided as an option. This is most useful in environments where `cross-fetch` is not compatible, for instance Cloudflare Workers:
+
+```js
+import { GoTrueClient } from '@supabase/gotrue-js'
+
+const GOTRUE_URL = 'http://localhost:9999'
+
+const auth = new GoTrueClient({ url: GOTRUE_URL, fetch: fetch })
+```
+
 ## Sponsors
 
 We are building the features of Firebase using enterprise-grade, open source products. We support existing communities wherever possible, and if the products don’t exist we build them and open source them ourselves.
 
 [![New Sponsor](https://user-images.githubusercontent.com/10214025/90518111-e74bbb00-e198-11ea-8f88-c9e3c1aa4b5b.png)](https://github.com/sponsors/supabase)
 
-![Watch this repo](https://gitcdn.xyz/repo/supabase/monorepo/master/web/static/watch-repo.gif "Watch this repo")
+![Watch this repo](https://gitcdn.xyz/repo/supabase/monorepo/master/web/static/watch-repo.gif 'Watch this repo')

--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -13,6 +13,7 @@ import {
   VerifyOTPParams,
 } from './lib/types'
 import { polyfillGlobalThis } from './lib/polyfills'
+import { Fetch } from './lib/fetch'
 
 polyfillGlobalThis() // Make "globalThis" available
 
@@ -65,6 +66,7 @@ export default class GoTrueClient {
    * @param options.persistSession Set to "true" if you want to automatically save the user session into local storage.
    * @param options.localStorage
    * @param options.cookieOptions
+   * @param options.fetch A custom fetch implementation.
    */
   constructor(options: {
     url?: string
@@ -74,6 +76,7 @@ export default class GoTrueClient {
     persistSession?: boolean
     localStorage?: SupportedStorage
     cookieOptions?: CookieOptions
+    fetch?: Fetch
   }) {
     const settings = { ...DEFAULT_OPTIONS, ...options }
     this.currentUser = null
@@ -85,6 +88,7 @@ export default class GoTrueClient {
       url: settings.url,
       headers: settings.headers,
       cookieOptions: settings.cookieOptions,
+      fetch: settings.fetch,
     })
     this._recoverSession()
     this._recoverAndRefresh()

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -1,4 +1,6 @@
-import fetch from 'cross-fetch'
+import crossFetch from 'cross-fetch'
+
+export type Fetch = typeof fetch
 
 export interface FetchOptions {
   headers?: {
@@ -38,13 +40,14 @@ const _getRequestParams = (method: RequestMethodType, options?: FetchOptions, bo
 }
 
 async function _handleRequest(
+  fetcher: Fetch = crossFetch,
   method: RequestMethodType,
   url: string,
   options?: FetchOptions,
   body?: object
 ): Promise<any> {
   return new Promise((resolve, reject) => {
-    fetch(url, _getRequestParams(method, options, body))
+    fetcher(url, _getRequestParams(method, options, body))
       .then((result) => {
         if (!result.ok) throw result
         if (options?.noResolveJson) return resolve
@@ -55,18 +58,37 @@ async function _handleRequest(
   })
 }
 
-export async function get(url: string, options?: FetchOptions): Promise<any> {
-  return _handleRequest('GET', url, options)
+export async function get(
+  fetcher: Fetch | undefined,
+  url: string,
+  options?: FetchOptions
+): Promise<any> {
+  return _handleRequest(fetcher, 'GET', url, options)
 }
 
-export async function post(url: string, body: object, options?: FetchOptions): Promise<any> {
-  return _handleRequest('POST', url, options, body)
+export async function post(
+  fetcher: Fetch | undefined,
+  url: string,
+  body: object,
+  options?: FetchOptions
+): Promise<any> {
+  return _handleRequest(fetcher, 'POST', url, options, body)
 }
 
-export async function put(url: string, body: object, options?: FetchOptions): Promise<any> {
-  return _handleRequest('PUT', url, options, body)
+export async function put(
+  fetcher: Fetch | undefined,
+  url: string,
+  body: object,
+  options?: FetchOptions
+): Promise<any> {
+  return _handleRequest(fetcher, 'PUT', url, options, body)
 }
 
-export async function remove(url: string, body: object, options?: FetchOptions): Promise<any> {
-  return _handleRequest('DELETE', url, options, body)
+export async function remove(
+  fetcher: Fetch | undefined,
+  url: string,
+  body: object,
+  options?: FetchOptions
+): Promise<any> {
+  return _handleRequest(fetcher, 'DELETE', url, options, body)
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR adds the ability to provide a custom `fetch` implementation as an option - this is most useful for environments where `cross-fetch` is not supported, for instance Cloudflare Workers or Vercel Edge Functions.

This is related to https://github.com/supabase/supabase-js/issues/154, and I believe a similar option would need to be added to the other libraries using `cross-fetch` before being finally added to `supabase-js`.

## What is the current behavior?

At the moment, `cross-fetch` is always used in all environments.

## What is the new behavior?

There is a new option `fetch` that can be provided to override `cross-fetch` with an alternative library (or the native `fetch`):

```js
import { GoTrueClient } from '@supabase/gotrue-js'

const GOTRUE_URL = 'http://localhost:9999'

const auth = new GoTrueClient({ url: GOTRUE_URL, fetch: fetch })
```

## Additional context

Wrapped library PRs:

- https://github.com/supabase/gotrue-js/pull/168 (this PR)
- https://github.com/supabase/postgrest-js/pull/222
- https://github.com/supabase/storage-js/pull/24

`supabase-js` PR:

- https://github.com/supabase/supabase-js/pull/297