### PR TITLE
fix: exports ApiError interface so can be used by third-party implementations

### DIFF
--- a/src/GoTrueApi.ts
+++ b/src/GoTrueApi.ts
@@ -4,11 +4,7 @@ import { COOKIE_OPTIONS } from './lib/constants'
 import { setCookie, deleteCookie } from './lib/cookies'
 import { expiresAt } from './lib/helpers'
 
-export interface ApiError {
-  message: string
-  status: number
-}
-
+import type { ApiError } from './lib/types'
 export default class GoTrueApi {
   protected url: string
   protected headers: {

--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -1,7 +1,11 @@
-import GoTrueApi, { ApiError } from './GoTrueApi'
+import GoTrueApi from './GoTrueApi'
 import { isBrowser, getParameterByName, uuid } from './lib/helpers'
 import { GOTRUE_URL, DEFAULT_HEADERS, STORAGE_KEY } from './lib/constants'
-import {
+import { polyfillGlobalThis } from './lib/polyfills'
+import { Fetch } from './lib/fetch'
+
+import type {
+  ApiError,
   Session,
   User,
   UserAttributes,
@@ -12,8 +16,6 @@ import {
   UserCredentials,
   VerifyOTPParams,
 } from './lib/types'
-import { polyfillGlobalThis } from './lib/polyfills'
-import { Fetch } from './lib/fetch'
 
 polyfillGlobalThis() // Make "globalThis" available
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -19,6 +19,11 @@ export type AuthChangeEvent =
   | 'USER_DELETED'
   | 'PASSWORD_RECOVERY'
 
+export interface ApiError {
+  message: string
+  status: number
+}
+
 export interface Session {
   provider_token?: string | null
   access_token: string


### PR DESCRIPTION
## What kind of change does this PR introduce?

When upgrading to the latest supabase-js (and hence gotrue-js) sdks for RedwoodJS, ran into the case where:

![image](https://user-images.githubusercontent.com/1051633/141815797-23bac5ec-1392-4a86-898a-084e34fb4d32.png)

Now the client returns GoTrueApi's `ApiError` can not just an `Error`.

But, it didn't see that `ApiError` was exported to allow a change in all the auth methods from, for example:

```ts
  login(options: {
    email?: string | undefined
    password?: string | undefined
    phone?: string | undefined
    provider?: Provider
    refreshToken?: string
    redirectTo?: string
    scopes?: string
  }): Promise<{
    session: Session | null
    user: User | null
    provider?: Provider
    url?: string | null
    error: Error | null
  }>
```

To use ` error: ApiError | null`


To match:

```
  async signIn(
    { email, phone, password, refreshToken, provider }: UserCredentials,
    options: {
      redirectTo?: string
      scopes?: string
    } = {}
  ): Promise<{
    session: Session | null
    user: User | null
    provider?: Provider
    url?: string | null
    error: ApiError | null <-----------------
    data: Session | null // Deprecated
  }> {
```

## What is the current behavior?

ApiError is not exported as a type.

## What is the new behavior?

* import types (for api and client) 
* ApiError interface moved into types

## Additional context

Since both GoTrueClient and GoTrueApi need `ApiError` I figured it was ok to move that into types.

but if there is a better place for it, let me know.

I didn't want to export it from GoTrueApi and import that in GoTrueClient.

For the PR that introduced APiError, see: https://github.com/supabase/gotrue-js/pull/137/files
