### PR TITLE
fix: Removes deprecated data for session

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -122,7 +122,6 @@ export default class GoTrueClient {
     user: User | null
     session: Session | null
     error: ApiError | null
-    data: Session | User | null // Deprecated
   }> {
     try {
       this._removeSession()
@@ -159,9 +158,9 @@ export default class GoTrueClient {
         user = data as User
       }
 
-      return { data, user, session, error: null }
+      return { user, session, error: null }
     } catch (e) {
-      return { data: null, user: null, session: null, error: e as ApiError }
+      return { user: null, session: null, error: e as ApiError }
     }
   }
 
@@ -187,7 +186,6 @@ export default class GoTrueClient {
     provider?: Provider
     url?: string | null
     error: ApiError | null
-    data: Session | null // Deprecated
   }> {
     try {
       this._removeSession()
@@ -196,7 +194,7 @@ export default class GoTrueClient {
         const { error } = await this.api.sendMagicLinkEmail(email, {
           redirectTo: options.redirectTo,
         })
-        return { data: null, user: null, session: null, error }
+        return { user: null, session: null, error }
       }
       if (email && password) {
         return this._handleEmailSignIn(email, password, {
@@ -205,7 +203,7 @@ export default class GoTrueClient {
       }
       if (phone && !password) {
         const { error } = await this.api.sendMobileOTP(phone)
-        return { data: null, user: null, session: null, error }
+        return { user: null, session: null, error }
       }
       if (phone && password) {
         return this._handlePhoneSignIn(phone, password)
@@ -216,7 +214,6 @@ export default class GoTrueClient {
         if (error) throw error
 
         return {
-          data: this.currentSession,
           user: this.currentUser,
           session: this.currentSession,
           error: null,
@@ -230,7 +227,7 @@ export default class GoTrueClient {
       }
       throw new Error(`You must provide either an email, phone number or a third-party provider.`)
     } catch (e) {
-      return { data: null, user: null, session: null, error: e as ApiError }
+      return { user: null, session: null, error: e as ApiError }
     }
   }
 
@@ -249,7 +246,6 @@ export default class GoTrueClient {
     user: User | null
     session: Session | null
     error: ApiError | null
-    data: Session | User | null // Deprecated
   }> {
     try {
       this._removeSession()
@@ -278,9 +274,9 @@ export default class GoTrueClient {
         user = data as User
       }
 
-      return { data, user, session, error: null }
+      return { user, session, error: null }
     } catch (e) {
-      return { data: null, user: null, session: null, error: e as ApiError }
+      return { user: null, session: null, error: e as ApiError }
     }
   }
 

--- a/test/clientWithAutoConfirmEnabled.test.ts
+++ b/test/clientWithAutoConfirmEnabled.test.ts
@@ -93,12 +93,12 @@ test('signUp() the same user twice should not share email already registered mes
     password: passwordSignupTwice,
   })
 
-  const { error, data, user } = await auth.signUp({
+  const { error, session, user } = await auth.signUp({
     email: emailSignupTwice,
     password: passwordSignupTwice,
   })
 
-  expect(data).toBeNull()
+  expect(session).toBeNull()
   expect(user).toBeNull()
 
   expect(error?.message).toMatch(/^User already registered/)
@@ -270,10 +270,10 @@ test('Get user after logging out', async () => {
 })
 
 test('signIn() with the wrong password', async () => {
-  const { error, data } = await auth.signIn({
+  const { error, session } = await auth.signIn({
     email,
     password: password + '2',
   })
   expect(error?.message).not.toBeNull()
-  expect(data).toBeNull()
+  expect(session).toBeNull()
 })

--- a/test/clientWithSignupsDisabled.test.ts
+++ b/test/clientWithSignupsDisabled.test.ts
@@ -20,12 +20,12 @@ const email = faker.internet.email().toLowerCase()
 const password = faker.internet.password()
 
 test('signUp()', async () => {
-  const { error, data, user } = await auth.signUp({
+  const { error, session, user } = await auth.signUp({
     email,
     password,
   })
   expect(error?.message).toBe('Signups not allowed for this instance')
-  expect(data).toBeNull()
+  expect(session).toBeNull()
   expect(user).toBeNull()
 })
 


### PR DESCRIPTION
## What kind of change does this PR introduce?
## What is the current behavior?
In the GoTrueClient, signIn, signUp and verifyOTP includes `data` as part of the response.

This `data` attributed is deprecated in favor of the `session`.

While the documentation for each no longer refers to being able to use `data` (see: https://supabase.io/docs/reference/javascript/auth-signup), each auth method stil provided for it and also the tests used data instead of session.

## What is the new behavior?

* Removes data from returned Promise of signIn, signUp, and verfifyOTP
* Replaces data for session in tests

## Additional context

The code can still be a little confusing in these cases, see `verifyOTP`:


```ts
      const { data, error } = await this.api.verifyMobileOTP(phone, token, options)

      if (error) {
        throw error
      }

      if (!data) {
        throw 'An error occurred on token verification.'
      }

      let session: Session | null = null
      let user: User | null = null

      if ((data as Session).access_token) {
        session = data as Session
```

Here, the GoTrueApi returns data ***which becomes*** the client's session, but in fact the API client really uses a session but then calls it data :)

```ts
async verifyMobileOTP(
    phone: string,
    token: string,
    options: {
      redirectTo?: string
    } = {}
  ): Promise<{ data: Session | User | null; error: ApiError | null }> {
    try {
      const headers = { ...this.headers }
      const data = await post(
        this.fetch,
        `${this.url}/verify`,
        { phone, token, type: 'sms', redirect_to: options.redirectTo },
        { headers }
      )
      return { data, error: null }
    } catch (e) {
      return { data: null, error: e as ApiError }
    }
  }
```

>   ): Promise<{ data: Session | User | null; error: ApiError | null }> {

That is, return `session` not `data`


Question: Perhaps session should be consistently used in both API and Client?