### PR TITLE
add typescript mapping for identities type

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -34,6 +34,19 @@ export interface Session {
   token_type: string
   user: User | null
 }
+
+export interface UserIdentity {
+  id: string
+  user_id: string 
+  identity_data: {
+    [key: string]: any
+  }
+  provider: string
+  created_at: string
+  last_sign_in_at: string
+  updated_at?: string
+}
+
 export interface User {
   id: string
   app_metadata: {
@@ -57,6 +70,7 @@ export interface User {
   last_sign_in_at?: string
   role?: string
   updated_at?: string
+  identities?: UserIdentity[]
 }
 
 export interface UserAttributes {


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Gotrue now returns a list of identities associated to a user in the user obj
* Added a `UserIdentity` interface and an `identities` field in User which is an array of `UserIdentity`
