### PR TITLE
bump docker supabase/postgres to 14.1.0

### DIFF
--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -104,9 +104,10 @@ services:
       - '9000:9000' # web interface
       - '1100:1100' # POP3
   db:
-    image: supabase/postgres
+    image: supabase/postgres:14.1.0
     ports:
       - '5432:5432'
+    command: postgres -c config_file=/etc/postgresql/postgresql.conf
     volumes:
       - ./db:/docker-entrypoint-initdb.d/
     environment:

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "lint": "eslint src/**/* test/**/*",
     "test": "run-s test:clean test:infra test:suite test:clean",
     "test:suite": "jest --runInBand",
-    "test:infra": "cd infra && docker-compose down && docker-compose pull && docker-compose up -d && sleep 10",
+    "test:infra": "cd infra && docker-compose down && docker-compose pull && docker-compose up -d && sleep 30",
     "test:clean": "cd infra && docker-compose down --remove-orphans",
     "docs": "typedoc src/index.ts",
     "docs:json": "typedoc src/index.ts --json docs/spec.json"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "lint": "eslint src/**/* test/**/*",
     "test": "run-s test:clean test:infra test:suite test:clean",
     "test:suite": "jest --runInBand",
-    "test:infra": "cd infra && docker-compose down && docker-compose pull && docker-compose up -d && sleep 30",
+    "test:infra": "cd infra && docker-compose down && docker-compose pull && docker-compose up -d && sleep 120",
     "test:clean": "cd infra && docker-compose down --remove-orphans",
     "docs": "typedoc src/index.ts",
     "docs:json": "typedoc src/index.ts --json docs/spec.json"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "lint": "eslint src/**/* test/**/*",
     "test": "run-s test:clean test:infra test:suite test:clean",
     "test:suite": "jest --runInBand",
-    "test:infra": "cd infra && docker-compose down && docker-compose pull && docker-compose up -d && sleep 120",
+    "test:infra": "cd infra && docker-compose down && docker-compose pull && docker-compose up -d && sleep 30",
     "test:clean": "cd infra && docker-compose down --remove-orphans",
     "docs": "typedoc src/index.ts",
     "docs:json": "typedoc src/index.ts --json docs/spec.json"


### PR DESCRIPTION
Should resolve #188. With the new version of the `supabase/postgres` image, there would be the need to explicitly specify the `postgresql.conf` location to `/etc/postgresql/postgresql.conf`.