### PR TITLE
Remove code coverage from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,12 +29,3 @@ jobs:
         run: |
           npm ci
           npm t
-
-      - name: Test & publish code coverage
-        uses: paambaati/codeclimate-action@v3.0.0
-        env:
-          CC_TEST_REPORTER_ID: ${{secrets.CC_TEST_REPORTER_ID}}
-        with:
-          coverageCommand: yarn run coverage
-          coverageLocations: |
-            ${{github.workspace}}/test/coverage/lcov.info:lcov


### PR DESCRIPTION
## What kind of change does this PR introduce?

As discussed with @kiwicopple we are removing Codecov from GoTrue-js to fix build

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
