### PR TITLE
Handle refresh offline

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -713,7 +713,10 @@ export default class GoTrueClient {
     if (this.refreshTokenTimer) clearTimeout(this.refreshTokenTimer)
     if (value <= 0 || !this.autoRefreshToken) return
 
-    this.refreshTokenTimer = setTimeout(() => this._callRefreshToken(), value)
+    this.refreshTokenTimer = setTimeout(async () => {
+      const { error } = await this._callRefreshToken()
+      if (error) throw error
+    }, value)
     if (typeof this.refreshTokenTimer.unref === 'function') this.refreshTokenTimer.unref()
   }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Closes #226

## What is the new behavior?

Does not try to refresh the token when offline, adds an event listener to refresh once online

## Additional context

Happy to discuss alternatives. I needed to make this change for a project so I thought I'd contribute it here.


