### PR TITLE
fix: properly default shouldCreateUser flag

### DIFF
--- a/src/GoTrueApi.ts
+++ b/src/GoTrueApi.ts
@@ -269,7 +269,7 @@ export default class GoTrueApi {
         queryString += '?redirect_to=' + encodeURIComponent(options.redirectTo)
       }
 
-      const shouldCreateUser = options.shouldCreateUser ? options.shouldCreateUser : true
+      const shouldCreateUser = options.shouldCreateUser ?? true
       const data = await post(
         this.fetch,
         `${this.url}/otp${queryString}`,
@@ -299,7 +299,7 @@ export default class GoTrueApi {
     } = {}
   ): Promise<{ data: {} | null; error: ApiError | null }> {
     try {
-      const shouldCreateUser = options.shouldCreateUser ? options.shouldCreateUser : true
+      const shouldCreateUser = options.shouldCreateUser ?? true
       const headers = { ...this.headers }
       const data = await post(
         this.fetch,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

The `shouldCreateUser` flag was added in #199, but passing `{ shouldCreateUser: false }` into the options of `signIn` still creates the user because this ternary will always return `true`:
```js
const shouldCreateUser = options.shouldCreateUser ? options.shouldCreateUser : true
```

## What is the new behavior?

With this change the `shouldCreateUser` can be set to `false` and the user will not be created, but it is still defaulted to `true` if no value (`undefined` or `null`) is passed.

## Additional context

Related to: https://github.com/supabase/supabase/issues/1176
