### PR TITLE
Add WorkOS Provider type

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -14,6 +14,7 @@ export type Provider =
   | 'spotify'
   | 'twitch'
   | 'twitter'
+  | 'workos'
 
 export type AuthChangeEvent =
   | 'PASSWORD_RECOVERY'


### PR DESCRIPTION
## What kind of change does this PR introduce?

Add WorkOS provider type to complement https://github.com/supabase/gotrue/pull/402 let's leave this here for now till we upgrade the GoTrue versions though.

## What is the current behavior?

no workos provider

## What is the new behavior?

workos provider added

## Additional context

Add any other context or screenshots.
