### PR TITLE
fix: add phone field to user attr

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -89,6 +89,11 @@ export interface UserAttributes {
   email?: string
 
   /**
+   * The user's phone.
+   */
+  phone?: string
+
+  /**
    * The user's password.
    */
   password?: string


### PR DESCRIPTION
## What kind of change does this PR introduce?
* `createUser` and `updateUser` should allow passing the `phone` field as an argument