### PR TITLE
fix: supabase/supabase-js#322 change event name of signUp() from "SIGNED_IN" to "SIGNED_UP"

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -163,7 +163,7 @@ export default class GoTrueClient {
         session = data as Session
         user = session.user as User
         this._saveSession(session)
-        this._notifyAllSubscribers('SIGNED_IN')
+        this._notifyAllSubscribers('SIGNED_UP')
       }
 
       if ((data as User).id) {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix supabase/supabase-js#322

## What is the current behavior?

[Please link any relevant issues here.
](https://github.com/supabase/supabase-js/issues/322)

## What is the new behavior?

Change event name of signUp() from "SIGNED_IN" to "SIGNED_UP"

## Additional context

None