### PR TITLE
refactor: add keepCurrentSession option for signUp()

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -120,13 +120,16 @@ export default class GoTrueClient {
    * @param phone The user's phone number.
    * @param redirectTo A URL or mobile address to send the user to after they are confirmed.
    * @param data Optional user metadata.
+   * @param keepCurrentSession Optional keep current session or not
    */
   async signUp(
     { email, password, phone }: UserCredentials,
     options: {
       redirectTo?: string
       data?: object
-      captchaToken?: string
+      captchaToken?: string,
+      keepCurrentSession?:boolean
+
     } = {}
   ): Promise<{
     user: User | null
@@ -134,7 +137,7 @@ export default class GoTrueClient {
     error: ApiError | null
   }> {
     try {
-      this._removeSession()
+      !options.keepCurrentSession && this._removeSession()
 
       const { data, error } =
         phone && password
@@ -160,14 +163,18 @@ export default class GoTrueClient {
       let user: User | null = null
 
       if ((data as Session).access_token) {
-        session = data as Session
-        user = session.user as User
-        this._saveSession(session)
+        if (!options.keepCurrentSession) {
+          session = data as Session
+          user = session.user as User
+          this._saveSession(session)
+        }
         this._notifyAllSubscribers('SIGNED_IN')
       }
 
       if ((data as User).id) {
-        user = data as User
+        if (!options.keepCurrentSession) {
+          user = data as User
+        }
       }
 
       return { user, session, error: null }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Add a boolean variable named `keepCurrentSession` to `signUp()` function.

## What is the current behavior?

Currently, there are not any options for developers to decide to keep or remove the current session after signing up.

## What is the new behavior?

Developers can actively decide whether the session should be kept or reset after signing up.
<img width="344" alt="image" src="https://user-images.githubusercontent.com/30664920/158080495-be1e1678-e987-4594-b01e-1266eee12131.png">


## Additional context

This idea was initiated when I'm building a system using Supabase where users with admin roles (store in public tables with UUID reference to the auth table) can create and manage other user account types (like staff, coordinator). However, when I use the signUp function in the Create New User page, the current session (admin) was removed and replaced by the credential of the new account. 
It's somehow really annoying, and I think this refactoring doesn't cause any conflicts to other parts, so it only improves the flexibility of usage for developers. I hope this PR will be merged as soon as possible because I've been stuck for a long time in my project before deciding to create this PR. Many thanks, GoTrue Team!