### PR TITLE
chore: refactor

### DIFF
--- a/src/GoTrueApi.ts
+++ b/src/GoTrueApi.ts
@@ -7,7 +7,7 @@ import {
   CookieOptions,
   User,
   OpenIDConnectCredentials,
-  VerifyOTPParams
+  VerifyOTPParams,
 } from './lib/types'
 import { COOKIE_OPTIONS } from './lib/constants'
 import { setCookies, getCookieString } from './lib/cookies'
@@ -337,7 +337,7 @@ export default class GoTrueApi {
   }
 
   /**
-   * @deprecated Send User supplied Mobile OTP to be verified
+   * @deprecated Use `verifyOTP` instead!
    * @param phone The user's phone number WITH international prefix
    * @param token token that user was sent to their mobile phone
    * @param redirectTo A URL or mobile address to send the user to after they are confirmed.
@@ -374,26 +374,19 @@ export default class GoTrueApi {
    * @param redirectTo A URL or mobile address to send the user to after they are confirmed.
    */
   async verifyOTP(
-    { email, phone, token, type }: VerifyOTPParams,
+    { email, phone, token, type = 'sms' }: VerifyOTPParams,
     options: {
       redirectTo?: string
     } = {}
   ): Promise<{ data: Session | User | null; error: ApiError | null }> {
     try {
       const headers = { ...this.headers }
-      const data = (email && type) 
-        ? await post(
-          this.fetch,
-          `${this.url}/verify`,
-          { email, token, type: type, redirect_to: options.redirectTo },
-          { headers }
-        )
-        : await post(
-          this.fetch,
-          `${this.url}/verify`,
-          { phone, token, type: 'sms', redirect_to: options.redirectTo },
-          { headers }
-        )
+      const data = await post(
+        this.fetch,
+        `${this.url}/verify`,
+        { email, phone, token, type, redirect_to: options.redirectTo },
+        { headers }
+      )
       const session = { ...data }
       if (session.expires_in) session.expires_at = expiresAt(data.expires_in)
       return { data: session, error: null }

--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -265,7 +265,7 @@ export default class GoTrueClient {
    * @param redirectTo A URL or mobile address to send the user to after they are confirmed.
    */
   async verifyOTP(
-    { email, phone, token, type = 'sms' }: VerifyOTPParams,
+    params: VerifyOTPParams,
     options: {
       redirectTo?: string
     } = {}
@@ -277,7 +277,7 @@ export default class GoTrueClient {
     try {
       this._removeSession()
 
-      const { data, error } = await this.api.verifyOTP({ email, phone, token, type }, options)
+      const { data, error } = await this.api.verifyOTP(params, options)
 
       if (error) {
         throw error

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -185,19 +185,21 @@ export interface UserCredentials {
   oidc?: OpenIDConnectCredentials
 }
 
-export interface VerifyOTPParams {
-  email?: string
-  phone?: string
+export type VerifyOTPParams = VerifyMobileOTPParams | VerifyEmailOTPParams
+export interface VerifyMobileOTPParams {
+  email?: undefined
+  phone: string
   token: string
-  type?: OTPType
+  type?: MobileOTPType
 }
-export type OTPType = 
-  | 'signup' 
-  | 'invite' 
-  | 'magiclink' 
-  | 'recover' 
-  | 'email_change' 
-  | 'sms'
+export interface VerifyEmailOTPParams {
+  email: string
+  phone?: undefined
+  token: string
+  type: EmailOTPType
+}
+export type MobileOTPType = 'sms'
+export type EmailOTPType = 'signup' | 'invite' | 'magiclink' | 'recover' | 'email_change'
 
 export interface OpenIDConnectCredentials {
   id_token: string

--- a/test/GoTrueApi.test.ts
+++ b/test/GoTrueApi.test.ts
@@ -4,7 +4,6 @@ import {
   clientApiAutoConfirmOffSignupsEnabledClient,
   serviceRoleApiClient,
   serviceRoleApiClientWithSms,
-  authClient,
   clientApiAutoConfirmDisabledClient,
 } from './lib/clients'
 
@@ -531,30 +530,28 @@ describe('GoTrueApi', () => {
       test('verifyOTP() with invalid email', async () => {
         const { email } = mockUserCredentials()
         const otp = mockVerificationOTP()
-        const { data, error } = await serviceRoleApiClientWithSms.verifyOTP({ 
-          email: `${email}-@invalid`, 
-          token: otp, 
-          type: 'signup' 
+        const { data, error } = await serviceRoleApiClientWithSms.verifyOTP({
+          email: `${email}-@invalid`,
+          token: otp,
+          type: 'signup',
         })
 
         expect(data).toBeNull()
         expect(error?.status).toEqual(422)
         expect(error?.message).toEqual('Invalid email format')
-        
       })
       test('verifyOTP() with invalid phone', async () => {
         const { phone } = mockUserCredentials()
         const otp = mockVerificationOTP()
-        const { data, error } = await serviceRoleApiClientWithSms.verifyOTP({ 
-          phone: `${phone}-invalid`, 
-          token: otp, 
-          type: 'sms' 
+        const { data, error } = await serviceRoleApiClientWithSms.verifyOTP({
+          phone: `${phone}-invalid`,
+          token: otp,
+          type: 'sms',
         })
 
         expect(data).toBeNull()
         expect(error?.status).toEqual(422)
         expect(error?.message).toEqual('Invalid phone number format')
-        
       })
     })
   })


### PR DESCRIPTION
@kangmingtay I've refactored the types and simplified the api and client a bit. 

With the types like this, `type` is optional when providing `phone` but is required when providing `email` 👍 