### PR TITLE
fix: unify localStorage acess

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -713,14 +713,14 @@ export default class GoTrueClient {
 
   private _persistSession(currentSession: Session) {
     const data = { currentSession, expiresAt: currentSession.expires_at }
-    isBrowser() && this.localStorage.setItem(STORAGE_KEY, JSON.stringify(data))
+    isBrowser() && this.localStorage?.setItem(STORAGE_KEY, JSON.stringify(data))
   }
 
   private async _removeSession() {
     this.currentSession = null
     this.currentUser = null
     if (this.refreshTokenTimer) clearTimeout(this.refreshTokenTimer)
-    isBrowser() && (await this.localStorage.removeItem(STORAGE_KEY))
+    isBrowser() && (await this.localStorage?.removeItem(STORAGE_KEY))
   }
 
   /**

--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -605,7 +605,7 @@ export default class GoTrueClient {
    * Attempts to get the session from LocalStorage
    * Note: this should never be async (even for React Native), as we need it to return immediately in the constructor.
    */
-  private _recoverSession() {
+  private async _recoverSession() {
     try {
       const json = isBrowser() && (await this.localStorage?.getItem(STORAGE_KEY))
       if (!json || typeof json !== 'string') {
@@ -711,9 +711,9 @@ export default class GoTrueClient {
     }
   }
 
-  private _persistSession(currentSession: Session) {
+  private async _persistSession(currentSession: Session) {
     const data = { currentSession, expiresAt: currentSession.expires_at }
-    isBrowser() && this.localStorage?.setItem(STORAGE_KEY, JSON.stringify(data))
+    isBrowser() && (await this.localStorage?.setItem(STORAGE_KEY, JSON.stringify(data)))
   }
 
   private async _removeSession() {

--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -607,7 +607,7 @@ export default class GoTrueClient {
    */
   private _recoverSession() {
     try {
-      const json = isBrowser() && this.localStorage?.getItem(STORAGE_KEY)
+      const json = isBrowser() && (await this.localStorage?.getItem(STORAGE_KEY))
       if (!json || typeof json !== 'string') {
         return null
       }
@@ -631,8 +631,8 @@ export default class GoTrueClient {
    */
   private async _recoverAndRefresh() {
     try {
-      const json = isBrowser() && (await this.localStorage.getItem(STORAGE_KEY))
-      if (!json) {
+      const json = isBrowser() && (await this.localStorage?.getItem(STORAGE_KEY))
+      if (!json || typeof json !== 'string') {
         return null
       }
 


### PR DESCRIPTION
Fixes the `TypeError: Cannot read properties of undefined (reading 'getItem')` error in Deno land.