### PR TITLE
fix: add methods for update password reauthentication

### DIFF
--- a/src/GoTrueApi.ts
+++ b/src/GoTrueApi.ts
@@ -832,4 +832,19 @@ export default class GoTrueApi {
       return { user: null, data: null, error: e as ApiError }
     }
   }
+
+  /**
+   * Sends a reauthentication otp to the user's email or phone number
+   * @param jwt A valid, logged-in JWT.
+   */
+  async reauthenticate(jwt: string): Promise<{ data: {} | null; error: ApiError | null }> {
+    try {
+      const data: any = await get(this.fetch, `${this.url}/reauthenticate`, {
+        headers: this._createRequestHeaders(jwt),
+      })
+      return { data: {}, error: null }
+    } catch (e) {
+      return { data: {}, error: e as ApiError }
+    }
+  }
 }

--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -762,4 +762,24 @@ export default class GoTrueClient {
       console.error('_listenForMultiTabEvents', error)
     }
   }
+
+  /**
+   * Sends a reauthentication otp to the user's email or phone number
+   */
+ async reauthenticate(): Promise<{ data: {} | null, error: ApiError | null }> {
+  try {
+    if (!this.currentSession?.access_token) throw new Error('Not logged in.')
+
+    const { error }: any = await this.api.reauthenticate(
+      this.currentSession.access_token,
+    )
+    if (error) throw error
+
+    return { data: {}, error: null }
+  } catch (e) {
+    return { data: null, error: e as ApiError }
+  }
 }
+}
+
+

--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -766,20 +766,18 @@ export default class GoTrueClient {
   /**
    * Sends a reauthentication otp to the user's email or phone number
    */
- async reauthenticate(): Promise<{ data: {} | null, error: ApiError | null }> {
-  try {
-    if (!this.currentSession?.access_token) throw new Error('Not logged in.')
+  async reauthenticate(): Promise<{ data: {} | null, error: ApiError | null }> {
+    try {
+      if (!this.currentSession?.access_token) throw new Error('Not logged in.')
 
-    const { error }: any = await this.api.reauthenticate(
-      this.currentSession.access_token,
-    )
-    if (error) throw error
+      const { error }: any = await this.api.reauthenticate(
+        this.currentSession.access_token,
+      )
+      if (error) throw error
 
-    return { data: {}, error: null }
-  } catch (e) {
-    return { data: null, error: e as ApiError }
+      return { data: {}, error: null }
+    } catch (e) {
+      return { data: null, error: e as ApiError }
+    }
   }
 }
-}
-
-

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -95,6 +95,11 @@ export interface UserAttributes {
   phone?: string
 
   /**
+   * The nonce sent for reauthentication
+   */
+  nonce?: string
+
+  /**
    * The user's password.
    */
   password?: string


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Provides corresponding methods for gotrue-js for password reauthentication
```
// To send a reauthentication request
supabase.auth.reauthenticate()

// To update password with reauthentication
supabase.auth.update({
  "password": "newpassword",
  "nonce": "123456"
})
```

## Steps to test
1. Enable `Update password requires reauthentication` on the dashboard
2. Initialise supabase client
3. Sign up with any method (password-based, passwordless or oauth)
4. Request for reauthentication `supabase.auth.reauthenticate()`
5. Update your password by calling `supabase.auth.update({...})`