### PR TITLE
fix: setAuth should not set user to null

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -404,7 +404,7 @@ export default class GoTrueClient {
       ...this.currentSession,
       access_token,
       token_type: 'bearer',
-      user: null,
+      user: this.user()
     }
 
     return this.currentSession


### PR DESCRIPTION
## What kind of change does this PR introduce?
* setAuth should set the user in the session to whatever it was originally
* Address #243 