### PR TITLE
fix: add phone_change otp type

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -199,7 +199,7 @@ export interface VerifyEmailOTPParams {
   token: string
   type: EmailOTPType
 }
-export type MobileOTPType = 'sms'
+export type MobileOTPType = 'sms' | 'phone_change'
 export type EmailOTPType = 'signup' | 'invite' | 'magiclink' | 'recovery' | 'email_change'
 
 export interface OpenIDConnectCredentials {


### PR DESCRIPTION
## What kind of change does this PR introduce?
* adds the `phone_change` otp type to the verify params