### PR TITLE
Docs don't reflect auth.api.SignOut behavior

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -469,7 +469,7 @@ export default class GoTrueClient {
    * Inside a browser context, `signOut()` will remove the logged in user from the browser session
    * and log them out - removing all items from localstorage and then trigger a "SIGNED_OUT" event.
    *
-   * For server-side management, you can disable sessions by passing a JWT through to `auth.api.signOut(JWT: string)`
+   * For server-side management, you can revoke all refresh tokens for a user by passing a user's JWT through to `auth.api.signOut(JWT: string)`. There is no way to revoke a user's session JWT before it automatically expires
    */
   async signOut(): Promise<{ error: ApiError | null }> {
     const accessToken = this.currentSession?.access_token


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix for docs. `signOut()` docs currently seem to indicate that an access token is deleted on the server upon this function being called, but this isn't the case. Instead all refresh tokens are all revoked instead and access tokens will stay alive until they expire.

## Additional context

There is some discussion of changing this behavior in https://github.com/supabase/gotrue/issues/248, but the current behavior of `signOut()` is to just revoke all refresh tokens.

Before allowing this change through, can someone who is more familiar with the supabase source confirm that I am not totally wrong here. I believe I am right because the supabase GoTrue docs say that `/logout` only revokes refresh tokens (https://github.com/supabase/gotrue#post-logout), and the auth.api.SignOut() just seems to call this endpoint https://github.com/supabase/gotrue-js/blob/2f183f421096755d3ae2bd4f698503422a6b8eea/src/GoTrueApi.ts#L325-L337

If this is incorrect, feel free to reject this PR.

## What kind of change does this PR introduce?

Bug fix, feature, docs update, ...

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
