### PR TITLE
fix: notify all subscribers when calling setAuth

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -407,6 +407,8 @@ export default class GoTrueClient {
       user: this.user()
     }
 
+    this._notifyAllSubscribers('TOKEN_REFRESHED')
+
     return this.currentSession
   }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Manually setting auth via `setAuth` does not notify any subscribers.

## What is the new behavior?

Manually setting auth via `setAuth` will notify all subscribers with event `TOKEN_REFRESHED`.

## Additional context

- See comment: https://github.com/supabase/supabase/issues/6290#issuecomment-1101831005
