### PR TITLE
feat: added async getSession/getUser method

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -323,6 +323,7 @@ export default class GoTrueClient {
    * Inside a browser context, `user()` will return the user data, if there is a logged in user.
    *
    * For server-side management, you can get a user through `auth.api.getUserByCookie()`
+   * @deprecated use `getUser()` instead
    */
   user(): User | null {
     return this.currentUser
@@ -330,6 +331,7 @@ export default class GoTrueClient {
 
   /**
    * Returns the session data, if there is an active session.
+   * @deprecated use `getSession()` instead
    */
   session(): Session | null {
     return this.currentSession
@@ -369,6 +371,35 @@ export default class GoTrueClient {
     }
 
     return { session, error: null }
+  }
+
+  /**
+   * Returns the user data, refreshing the session if necessary.
+   */
+  async getUser(): Promise<
+    | {
+        user: User
+        error: null
+      }
+    | {
+        user: null
+        error: ApiError
+      }
+    | {
+        user: null
+        error: null
+      }
+  > {
+    const { session, error } = await this.getSession()
+    if (error) {
+      return { user: null, error }
+    }
+
+    if (!session) {
+      return { user: null, error: null }
+    }
+
+    return { user: session.user, error: null }
   }
 
   /**

--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -335,6 +335,9 @@ export default class GoTrueClient {
     return this.currentSession
   }
 
+  /**
+   * Returns the session data, refreshing it if necessary.
+   */
   async getSession(): Promise<
     | {
         session: Session

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -75,3 +75,25 @@ export const getItemSynchronously = (storage: SupportedStorage, key: string): an
 export const removeItemAsync = async (storage: SupportedStorage, key: string): Promise<void> => {
   isBrowser() && (await storage?.removeItem(key))
 }
+
+/**
+ * A deferred represents some asynchronous work that is not yet finished, which
+ * may or may not culminate in a value.
+ * Taken from: https://github.com/mike-north/types/blob/master/src/async.ts
+ */
+export class Deferred<T = any> {
+  public static promiseConstructor: PromiseConstructor = Promise
+
+  public readonly promise!: PromiseLike<T>
+
+  public readonly resolve!: (value?: T | PromiseLike<T>) => void
+
+  public readonly reject!: (reason?: any) => any
+
+  public constructor() {
+    (this as any).promise = new Deferred.promiseConstructor((res, rej) => {
+      (this as any).resolve = res
+      ;(this as any).reject = rej
+    })
+  }
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

This is a proof of concept for a new async `getSession()` method. This allows users to get a valid session (not expired) as opposed to the synchronous `session()` method, which may return an expired session.

## Additional context

I know we're planning to discuss this further, but since I already had most of the code, I thought I'd throw something together quickly. It will hopefully make our discussion clearer if we have something to look at!

Once `gotrue-js` has a method like this (or similar) it will allow `supabase-js` to work something like:

```javascript
async function getAccessToken() {
    const {session} = await auth.getSession()

    return session?.access_token ?? null
}

const postgrestClient = new PostgrestClient({ getAccessToken, ... })
```

Then whenever `postgrestClient` is about to send a query, it can call the `getAccessToken()` method, which will return an up-to-date token.

Note: While this isn't a breaking change in `gotrue-js` (purely additive), it will be a breaking change once we start doing the above in `supabase-js`, as some users may rely on the first request possible sending an expired token. We may consider ignoring this use case though, as it is a strange one!
--
Resolves #143 and #23
Supersedes #265 and #147