### PR TITLE
build(release-next): sets up the next branch as an npm prerelease

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+      - next
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - next
   workflow_dispatch:
 
 jobs:

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,4 +1,5 @@
 {
+  "branches": [{ "name": "master" }, { "name": "next", "channel": "next", "prerelease": true }],
   "plugins": [
     [
       "semantic-release-plugin-update-version-in-files",


### PR DESCRIPTION
## What kind of change does this PR introduce?

Sets up the next branch as an npm prerelease

## What is the current behavior?

There is currently no prerelease pipeline.

## What is the new behavior?

Pushes to the next branch will be included as an npm prerelease under the `next` tag.

## Additional context

Prereleases will look like:
<img width="768" alt="Screen Shot 2022-06-06 at 4 41 22 pm" src="https://user-images.githubusercontent.com/10985857/172109240-953fa696-7022-4194-91bf-a1c771238db7.png">

If this works as intended and we're happy I'll also add this to `supabase-js`
