### PR TITLE
fix: getSession() read from localStorage every time

### DIFF
--- a/test/GoTrueClient.test.ts
+++ b/test/GoTrueClient.test.ts
@@ -87,10 +87,10 @@ describe('GoTrueClient', () => {
       expired.setMinutes(expired.getMinutes() - 1)
       const expiredSeconds = Math.floor(expired.getTime() / 1000)
 
-      // @ts-expect-error 'Allow access to protected currentSession'
-      authWithSession.currentSession = {
-        // @ts-expect-error 'Allow access to protected currentSession'
-        ...authWithSession.currentSession,
+      // @ts-expect-error 'Allow access to protected inMemorySession'
+      authWithSession.inMemorySession = {
+        // @ts-expect-error 'Allow access to protected inMemorySession'
+        ...authWithSession.inMemorySession,
         expires_at: expiredSeconds,
       }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behaviour?

When the session is expired the new `getSession()` handler does not refresh it as `_recoverSession()` does not set `this.currentSession` if it has expired, so `getSession()` thinks the user is logged out.

## What is the new behaviour?

`getSession()` reads from local storage (or in-memory storage) on every call, rather than relying on `this.currentSession`.
This also sets us up for the future, when we will be able to remove all the cross tab synchronisation logic.

## Additional context

This PR also deprecates a bunch of stuff, most notably `setAuth()`. As we're moving away from `this.currentSession`, `setAuth()` will not be needed to synchronise sessions across gotrue instances, as it can now be done via storage.
