### PR TITLE
Possible change of error message when getting session fails

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -112,7 +112,7 @@ export default class GoTrueClient {
       // Handle the OAuth redirect
       this.getSessionFromUrl({ storeSession: true }).then(({ error }) => {
         if (error) {
-          console.error('Error getting session from URL.', error)
+          console.warn('Error getting session from URL.', error)
         }
       })
     }

--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -112,7 +112,7 @@ export default class GoTrueClient {
       // Handle the OAuth redirect
       this.getSessionFromUrl({ storeSession: true }).then(({ error }) => {
         if (error) {
-          console.warn('Error getting session from URL.', error)
+          throw new Error('Error getting session from URL.')
         }
       })
     }

--- a/test/GoTrueApi.test.ts
+++ b/test/GoTrueApi.test.ts
@@ -361,8 +361,8 @@ describe('GoTrueApi', () => {
           redirectTo,
         }
       )
-      expect(user).toEqual({})
-      console.log(error)
+
+      expect(user).toBeNull()
       expect(error?.message).toEqual('User not found')
     })
 

--- a/test/GoTrueApi.test.ts
+++ b/test/GoTrueApi.test.ts
@@ -361,8 +361,8 @@ describe('GoTrueApi', () => {
           redirectTo,
         }
       )
-
-      expect(user).toBeNull()
+      expect(user).toEqual({})
+      console.log(error)
       expect(error?.message).toEqual('User not found')
     })
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Changes  the console log on error in getting session from URL from error -> to warn in order to fix  #240 . Seems more a DX thing so looping in Thor and Silentworks.


## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
