### PR TITLE
Bump CI to node 14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node: ['12']
+        node: ['14']
 
     runs-on: ${{ matrix.os }}
 

--- a/test/GoTrueApi.test.ts
+++ b/test/GoTrueApi.test.ts
@@ -353,6 +353,19 @@ describe('GoTrueApi', () => {
       expect(error?.message).toBeUndefined()
     })
 
+    test('resetPasswordForEmail() if user does not exist, cannot send an email for password recovery', async () => {
+      const redirectTo = 'http://localhost:9999/welcome'
+      const { error, data: user } = await serviceRoleApiClient.resetPasswordForEmail(
+        'this_user@does-not-exist.com',
+        {
+          redirectTo,
+        }
+      )
+      expect(user).toEqual({})
+      console.log(error)
+      expect(error?.message).toEqual('User not found')
+    })
+
     test('refreshAccessToken()', async () => {
       const { email, password } = mockUserCredentials()
 

--- a/test/GoTrueApi.test.ts
+++ b/test/GoTrueApi.test.ts
@@ -333,7 +333,7 @@ describe('GoTrueApi', () => {
   })
 
   describe('User management', () => {
-    test('resetPasswordForEmail() sends an email for  password recovery', async () => {
+    test('resetPasswordForEmail() sends an email for password recovery', async () => {
       const { email, password } = mockUserCredentials()
 
       const { error: initialError, session } = await authClientWithSession.signUp({
@@ -353,7 +353,7 @@ describe('GoTrueApi', () => {
       expect(error?.message).toBeUndefined()
     })
 
-    test('resetPasswordForEmail() if user does not exist, cannot send an email for password recovery', async () => {
+    test('resetPasswordForEmail() if user does not exist, user details are not exposed', async () => {
       const redirectTo = 'http://localhost:9999/welcome'
       const { error, data: user } = await serviceRoleApiClient.resetPasswordForEmail(
         'this_user@does-not-exist.com',
@@ -362,8 +362,7 @@ describe('GoTrueApi', () => {
         }
       )
       expect(user).toEqual({})
-      console.log(error)
-      expect(error?.message).toEqual('User not found')
+      expect(error).toBeNull()
     })
 
     test('refreshAccessToken()', async () => {

--- a/test/GoTrueApi.test.ts
+++ b/test/GoTrueApi.test.ts
@@ -361,8 +361,8 @@ describe('GoTrueApi', () => {
           redirectTo,
         }
       )
-
-      expect(user).toBeNull()
+      expect(user).toEqual({})
+      console.log(error)
       expect(error?.message).toEqual('User not found')
     })
 

--- a/test/GoTrueApi.test.ts
+++ b/test/GoTrueApi.test.ts
@@ -353,19 +353,6 @@ describe('GoTrueApi', () => {
       expect(error?.message).toBeUndefined()
     })
 
-    test('resetPasswordForEmail() if user does not exist, cannot send an email for password recovery', async () => {
-      const redirectTo = 'http://localhost:9999/welcome'
-      const { error, data: user } = await serviceRoleApiClient.resetPasswordForEmail(
-        'this_user@does-not-exist.com',
-        {
-          redirectTo,
-        }
-      )
-      expect(user).toEqual({})
-      console.log(error)
-      expect(error?.message).toEqual('User not found')
-    })
-
     test('refreshAccessToken()', async () => {
       const { email, password } = mockUserCredentials()
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bumps CI to node 14 to mirror supabase-js. 

Also removes the test which validates that user cannot send a recovery email if a user doesn't exist because the changes in [this GoTrue PR](https://github.com/supabase/gotrue/pull/534) make the test no longer relevant.

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
