### PR TITLE
Reduce some duplication in GoTrueApi

### DIFF
--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -42,7 +42,7 @@ const _getRequestParams = (method: RequestMethodType, options?: FetchOptions, bo
   return params
 }
 
-async function _handleRequest(
+export async function request(
   fetcher: Fetch,
   method: RequestMethodType,
   url: string,
@@ -59,35 +59,4 @@ async function _handleRequest(
       .then((data) => resolve(data))
       .catch((error) => handleError(error, reject))
   })
-}
-
-export async function get(fetcher: Fetch, url: string, options?: FetchOptions): Promise<any> {
-  return _handleRequest(fetcher, 'GET', url, options)
-}
-
-export async function post(
-  fetcher: Fetch,
-  url: string,
-  body: object,
-  options?: FetchOptions
-): Promise<any> {
-  return _handleRequest(fetcher, 'POST', url, options, body)
-}
-
-export async function put(
-  fetcher: Fetch,
-  url: string,
-  body: object,
-  options?: FetchOptions
-): Promise<any> {
-  return _handleRequest(fetcher, 'PUT', url, options, body)
-}
-
-export async function remove(
-  fetcher: Fetch,
-  url: string,
-  body: object,
-  options?: FetchOptions
-): Promise<any> {
-  return _handleRequest(fetcher, 'DELETE', url, options, body)
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?
Refactor / DRY

## What is the current behavior?
A lot of copy/paste code inside GoTrueAPI

## What is the new behavior?
Refactored repetitive code inside of functions so that they can be re-used.

## Additional context
!!
**I am not a typescript/javascript developer.** 
!!

Also, I think these changes are pretty subjective, so...I wouldn't have my feelings hurt to have it rejected :)


Repeating yourself is often useful, but I think having 5 places do:
```
const session = { ...data }
if (session.expires_in) session.expires_at = expiresAt(data.expires_in)
return { data: session, error: null }
```

Isn't great. As a reader, I need to read all 5 closely to figure out if there's a [subtle] difference between them or not.Whereas, having them all use that same function makes the intent "these are all the same" much more obvious

