### PR TITLE
fix: resolve & reset deferred upon refresh error

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -803,14 +803,14 @@ export default class GoTrueClient {
       return result
     } catch (error) {
       if (isAuthError(error)) {
-        const result = { session: null, error };
+        const result = { session: null, error }
 
-        this.refreshingDeferred?.resolve(result);
+        this.refreshingDeferred?.resolve(result)
 
-        return result;
+        return result
       }
 
-      this.refreshingDeferred?.reject(error);
+      this.refreshingDeferred?.reject(error)
       throw error
     } finally {
       this.refreshingDeferred = null

--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -44,17 +44,10 @@ import type {
   SignInWithPasswordlessCredentials,
   AuthResponse,
   OAuthResponse,
+  CallRefreshTokenResult,
 } from './lib/types'
 
 polyfillGlobalThis() // Make "globalThis" available
-
-type CallRefreshTokenResult = {
-  session: Session
-  error: null
-} | {
-  session: null
-  error: AuthError
-}
 
 const DEFAULT_OPTIONS = {
   url: GOTRUE_URL,

--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -925,6 +925,7 @@ export default class GoTrueClient {
         return result;
       }
 
+      this.refreshingDeferred?.reject(error);
       throw error
     } finally {
       this.refreshingDeferred = null

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -272,3 +272,11 @@ type PromisifyMethods<T> = {
 }
 
 export type SupportedStorage = PromisifyMethods<Pick<Storage, 'getItem' | 'setItem' | 'removeItem'>>
+
+export type CallRefreshTokenResult = {
+  session: Session
+  error: null
+} | {
+  session: null
+  error: AuthError
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -273,10 +273,12 @@ type PromisifyMethods<T> = {
 
 export type SupportedStorage = PromisifyMethods<Pick<Storage, 'getItem' | 'setItem' | 'removeItem'>>
 
-export type CallRefreshTokenResult = {
-  session: Session
-  error: null
-} | {
-  session: null
-  error: AuthError
-}
+export type CallRefreshTokenResult =
+  | {
+      session: Session
+      error: null
+    }
+  | {
+      session: null
+      error: AuthError
+    }

--- a/test/GoTrueClient.test.ts
+++ b/test/GoTrueClient.test.ts
@@ -1,4 +1,4 @@
-import { AuthError } from '../src/lib/errors';
+import { AuthError } from '../src/lib/errors'
 import {
   authClient as auth,
   authClientWithSession as authWithSession,
@@ -117,10 +117,12 @@ describe('GoTrueClient', () => {
 
     test('_callRefreshToken() should resolve all pending refresh requests and reset deferred upon AuthError', async () => {
       const { email, password } = mockUserCredentials()
-      refreshAccessTokenSpy.mockImplementationOnce(() => Promise.resolve({
-        session: null,
-        error: new AuthError('Something did not work as expected')
-      }))
+      refreshAccessTokenSpy.mockImplementationOnce(() =>
+        Promise.resolve({
+          session: null,
+          error: new AuthError('Something did not work as expected'),
+        })
+      )
 
       const { error, session } = await authWithSession.signUp({
         email,
@@ -131,8 +133,12 @@ describe('GoTrueClient', () => {
       expect(session).not.toBeNull()
 
       const [{ session: session1, error: error1 }, { session: session2, error: error2 }] =
-        // @ts-expect-error 'Allow access to private _callRefreshToken()'
-        await Promise.all([authWithSession._callRefreshToken(session?.refresh_token), authWithSession._callRefreshToken(session?.refresh_token)])
+        await Promise.all([
+          // @ts-expect-error 'Allow access to private _callRefreshToken()'
+          authWithSession._callRefreshToken(session?.refresh_token),
+          // @ts-expect-error 'Allow access to private _callRefreshToken()'
+          authWithSession._callRefreshToken(session?.refresh_token),
+        ])
 
       expect(error1).toHaveProperty('message')
       expect(error2).toHaveProperty('message')
@@ -143,14 +149,16 @@ describe('GoTrueClient', () => {
 
       // vreify the deferred has been reset and successive calls can be made
       // @ts-expect-error 'Allow access to private _callRefreshToken()'
-      const { session: session3, error: error3 } = await authWithSession._callRefreshToken(session?.refresh_token)
+      const { session: session3, error: error3 } = await authWithSession._callRefreshToken(
+        session?.refresh_token
+      )
 
       expect(error3).toBeNull()
       expect(session3).toHaveProperty('access_token')
     })
 
     test('_callRefreshToken() should reject all pending refresh requests and reset deferred upon any non AuthError', async () => {
-      const mockError = new Error('Something did not work as expected');
+      const mockError = new Error('Something did not work as expected')
 
       const { email, password } = mockUserCredentials()
       refreshAccessTokenSpy.mockImplementationOnce(() => Promise.reject(mockError))
@@ -164,8 +172,12 @@ describe('GoTrueClient', () => {
       expect(session).not.toBeNull()
 
       const [error1, error2] =
-        // @ts-expect-error 'Allow access to private _callRefreshToken()'
-        await Promise.allSettled([authWithSession._callRefreshToken(session?.refresh_token), authWithSession._callRefreshToken(session?.refresh_token)])
+        await Promise.allSettled([
+          // @ts-expect-error 'Allow access to private _callRefreshToken()'
+          authWithSession._callRefreshToken(session?.refresh_token),
+          // @ts-expect-error 'Allow access to private _callRefreshToken()'
+          authWithSession._callRefreshToken(session?.refresh_token),
+        ])
 
       expect(error1.status).toEqual('rejected')
       expect(error2.status).toEqual('rejected')
@@ -178,7 +190,9 @@ describe('GoTrueClient', () => {
 
       // vreify the deferred has been reset and successive calls can be made
       // @ts-expect-error 'Allow access to private _callRefreshToken()'
-      const { session: session3, error: error3 } = await authWithSession._callRefreshToken(session?.refresh_token)
+      const { session: session3, error: error3 } = await authWithSession._callRefreshToken(
+        session?.refresh_token
+      )
 
       expect(error3).toBeNull()
       expect(session3).toHaveProperty('access_token')

--- a/test/GoTrueClient.test.ts
+++ b/test/GoTrueClient.test.ts
@@ -147,7 +147,7 @@ describe('GoTrueClient', () => {
 
       expect(refreshAccessTokenSpy).toBeCalledTimes(1)
 
-      // vreify the deferred has been reset and successive calls can be made
+      // verify the deferred has been reset and successive calls can be made
       // @ts-expect-error 'Allow access to private _callRefreshToken()'
       const { session: session3, error: error3 } = await authWithSession._callRefreshToken(
         session!.refresh_token

--- a/test/GoTrueClient.test.ts
+++ b/test/GoTrueClient.test.ts
@@ -150,7 +150,7 @@ describe('GoTrueClient', () => {
       // vreify the deferred has been reset and successive calls can be made
       // @ts-expect-error 'Allow access to private _callRefreshToken()'
       const { session: session3, error: error3 } = await authWithSession._callRefreshToken(
-        session?.refresh_token
+        session!.refresh_token
       )
 
       expect(error3).toBeNull()
@@ -191,7 +191,7 @@ describe('GoTrueClient', () => {
       // vreify the deferred has been reset and successive calls can be made
       // @ts-expect-error 'Allow access to private _callRefreshToken()'
       const { session: session3, error: error3 } = await authWithSession._callRefreshToken(
-        session?.refresh_token
+        session!.refresh_token
       )
 
       expect(error3).toBeNull()


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?
Currently `refreshingDeferred` does not get resolved/rejected upon error. Also the deferred does not get reset to null during an error. See #334 

## What is the new behavior?

The deferred gets resolved upon AuthError and rejected upon other errors, and finally reset to null. Like this the deferred Promise behaves like the Promise returned by `_callRefreshToken` itself.

## Additional context

Closes #334 
