### PR TITLE
fix: add custom error classes

### DIFF
--- a/src/GoTrueApi.ts
+++ b/src/GoTrueApi.ts
@@ -13,7 +13,7 @@ import { COOKIE_OPTIONS } from './lib/constants'
 import { setCookies, getCookieString } from './lib/cookies'
 import { expiresAt, resolveFetch } from './lib/helpers'
 
-import { isAuthError, AuthError, AuthApiError } from './lib/errors'
+import { isAuthError, AuthError, AuthApiError, AuthSessionMissingError, AuthEventMissingError, AuthNoCookieError } from './lib/errors'
 
 export default class GoTrueApi {
   protected url: string
@@ -632,9 +632,9 @@ export default class GoTrueApi {
     }
     const { event, session } = req.body
 
-    if (!event) throw new Error('Auth event missing!')
+    if (!event) throw new AuthEventMissingError()
     if (event === 'SIGNED_IN') {
-      if (!session) throw new Error('Auth session missing!')
+      if (!session) throw new AuthSessionMissingError()
       setCookies(
         req,
         res,
@@ -697,9 +697,9 @@ export default class GoTrueApi {
     }
     const { event, session } = req.body
 
-    if (!event) throw new Error('Auth event missing!')
+    if (!event) throw new AuthEventMissingError()
     if (event === 'SIGNED_IN') {
-      if (!session) throw new Error('Auth session missing!')
+      if (!session) throw new AuthSessionMissingError()
       return getCookieString(
         req,
         res,
@@ -885,7 +885,7 @@ export default class GoTrueApi {
       const refresh_token = req.cookies[`${this.cookieName()}-refresh-token`]
 
       if (!access_token) {
-        throw new Error('No cookie found!')
+        throw new AuthNoCookieError()
       }
 
       const { user, error } = await this.getUser(access_token)

--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -37,7 +37,7 @@ import type {
   SignInWithOAuthCredentials,
   SignInWithPasswordlessCredentials,
   AuthResponse,
-  OAuthResposne,
+  OAuthResponse,
 } from './lib/types'
 
 polyfillGlobalThis() // Make "globalThis" available
@@ -240,7 +240,7 @@ export default class GoTrueClient {
    * @param scopes A space-separated list of scopes granted to the OAuth application.
    * @param queryParams An object of query params
    */
-  async signInWithOAuth(credentials: SignInWithOAuthCredentials): Promise<OAuthResposne> {
+  async signInWithOAuth(credentials: SignInWithOAuthCredentials): Promise<OAuthResponse> {
     try {
       this._removeSession()
       return this._handleProviderSignIn(credentials.provider, {

--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -556,15 +556,15 @@ export default class GoTrueClient {
   async signOut(): Promise<{ error: AuthError | null }> {
     const { session, error: sessionError } = await this.getSession()
     if (sessionError) {
-      throw sessionError
+      return { error: sessionError }
     }
     const accessToken = session?.access_token
-    this._removeSession()
-    this._notifyAllSubscribers('SIGNED_OUT', session)
     if (accessToken) {
       const { error } = await this.api.signOut(accessToken)
       if (error) return { error }
     }
+    this._removeSession()
+    this._notifyAllSubscribers('SIGNED_OUT', null)
     return { error: null }
   }
 

--- a/src/lib/cookies.ts
+++ b/src/lib/cookies.ts
@@ -1,3 +1,5 @@
+import { AuthUnknownError } from "./errors"
+
 type Cookie = {
   name: string
   value: string
@@ -112,7 +114,7 @@ function serialize(
  */
 function isSecureEnvironment(req: any) {
   if (!req || !req.headers || !req.headers.host) {
-    throw new Error('The "host" request header is not available')
+    throw new AuthUnknownError('The "host" request header is not available', new Error('The "host" request header is not available'))
   }
 
   const host =

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -38,3 +38,45 @@ export class AuthUnknownError extends AuthError {
     this.originalError = originalError
   }
 }
+
+export class CustomAuthError extends AuthError {
+  name: string
+  status: number
+  constructor(message: string, name: string, status: number) {
+    super(message)
+    this.name = name
+    this.status = status
+  }
+  
+  toJSON() {
+    return {
+      name: this.name,
+      message: this.message,
+      status: this.status
+    }
+  }
+}
+
+export class AuthEventMissingError extends CustomAuthError {
+  constructor() {
+    super('Auth event missing!', 'AuthEventMissingError', 400)
+  }
+}
+
+export class AuthSessionMissingError extends CustomAuthError {
+  constructor() {
+    super('Auth session missing!', 'AuthSessionMissingError', 400)
+  }
+}
+
+export class AuthNoCookieError extends CustomAuthError {
+  constructor() {
+    super('No cooke found!', 'AuthNoCookieError', 401)
+  }
+}
+
+export class AuthInvalidCredentialsError extends CustomAuthError {
+  constructor(message: string) {
+    super(message, 'AuthInvalidCredentialsError', 400)
+  }
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -36,7 +36,7 @@ export type AuthResponse = {
   error: AuthError
 } 
 
-export type OAuthResposne = {
+export type OAuthResponse = {
   provider: Provider
   url: string
   error: null


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Use a custom error class that extends `AuthError` instead of throwing a generic error