### PR TITLE
fix: remove _recoverSession

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -5,7 +5,6 @@ import {
   uuid,
   setItemAsync,
   removeItemAsync,
-  getItemSynchronously,
   getItemAsync,
   Deferred,
 } from './lib/helpers'
@@ -125,7 +124,6 @@ export default class GoTrueClient {
       cookieOptions: settings.cookieOptions,
       fetch: settings.fetch,
     })
-    this._recoverSession()
     this._recoverAndRefresh()
     this._handleVisibilityChange()
 
@@ -718,29 +716,6 @@ export default class GoTrueClient {
   }
 
   /**
-   * Attempts to get the session from LocalStorage
-   * Note: this should never be async (even for React Native), as we need it to return immediately in the constructor.
-   */
-  private _recoverSession() {
-    try {
-      const data = getItemSynchronously(this.localStorage, this.storageKey)
-      if (!data) return null
-      const { currentSession, expiresAt } = data
-      const timeNow = Math.round(Date.now() / 1000)
-
-      if (expiresAt >= timeNow + EXPIRY_MARGIN && currentSession?.user) {
-        // should only save the session when it's coming from localStorage
-        // if the user has persistSession enabled
-        if (this.persistSession) {
-          this._saveSession(currentSession)
-        }
-      }
-    } catch (error) {
-      console.log('error', error)
-    }
-  }
-
-  /**
    * Recovers the session from LocalStorage and refreshes
    * Note: this method is async to accommodate for AsyncStorage e.g. in React native.
    */
@@ -778,8 +753,6 @@ export default class GoTrueClient {
         console.log('Current session is missing data.')
         this._removeSession()
       } else {
-        // should be handled on _recoverSession method already
-        // But we still need the code here to accommodate for AsyncStorage e.g. in React native
         if (this.persistSession) {
           this._saveSession(currentSession)
         }

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -67,18 +67,6 @@ export const getItemAsync = async (storage: SupportedStorage, key: string): Prom
   }
 }
 
-export const getItemSynchronously = (storage: SupportedStorage, key: string): any | null => {
-  const value = isBrowser() && storage?.getItem(key)
-  if (!value || typeof value !== 'string') {
-    return null
-  }
-  try {
-    return JSON.parse(value)
-  } catch {
-    return value
-  }
-}
-
 export const removeItemAsync = async (storage: SupportedStorage, key: string): Promise<void> => {
   isBrowser() && (await storage?.removeItem(key))
 }


### PR DESCRIPTION
The `_recoverSession` is now redundant as we read the session from `localStorage` every time.

@kangmingtay it also looks like we're duplicating the refresh timer logic in `_recoverAndRefresh` and `_saveSession`. I think we can pull this out into another method and then call it as needed. What do you think?