### PR TITLE
fix: add email change types to generateLink

### DIFF
--- a/src/GoTrueApi.ts
+++ b/src/GoTrueApi.ts
@@ -614,7 +614,13 @@ export default class GoTrueApi {
    * @param redirectTo The link type ("signup" or "magiclink" or "recovery" or "invite").
    */
   async generateLink(
-    type: 'signup' | 'magiclink' | 'recovery' | 'invite',
+    type:
+      | 'signup'
+      | 'magiclink'
+      | 'recovery'
+      | 'invite'
+      | 'email_change_current'
+      | 'email_change_new',
     email: string,
     options: {
       password?: string


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Added support for generating email change links in (https://github.com/supabase/gotrue/pull/560) 