### PR TITLE
Add initialized method to client

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -51,6 +51,10 @@ export default class GoTrueClient {
    */
   api: GoTrueApi
   /**
+   * Resolved when the initializing of the user session, if one exists, is complete.
+   */
+  protected initializedPromise: Promise<void>;
+  /**
    * The currently logged in user or null.
    */
   protected currentUser: User | null
@@ -104,7 +108,7 @@ export default class GoTrueClient {
       fetch: settings.fetch,
     })
     this._recoverSession()
-    this._recoverAndRefresh()
+    this.initializedPromise = this._recoverAndRefresh().then(() => undefined);
     this._listenForMultiTabEvents()
     this._handleVisibilityChange()
 
@@ -116,6 +120,13 @@ export default class GoTrueClient {
         }
       })
     }
+  }
+
+  /**
+   * @returns A promise that resolves when the initializing of the user session, if one exists, is complete.
+   */
+  initialized(): Promise<void> {
+    return this.initializedPromise;
   }
 
   /**


### PR DESCRIPTION
Returns a promise that is resolved when the initializing of the user session is complete.

## What kind of change does this PR introduce?

Bug fix for https://github.com/supabase/gotrue-js/issues/326

## What is the current behavior?

It is not possible to know when the client has finished reading the saved session after construction.

## What is the new behavior?

The promise returned from `initialized()` is resolved when the saved session, if one exists, has been restored:

```ts
const client = new GoTrueClient(options);

// any time later
await client.initialized();
if (client.user()) {
  // signed in
} else {
  // not signed in
  client.signIn(credentials);
}
```
