### PR TITLE
feat: refactor storage key

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -52,7 +52,6 @@ polyfillGlobalThis() // Make "globalThis" available
 
 const DEFAULT_OPTIONS = {
   url: GOTRUE_URL,
-  persistenceKey: PERSISTENCE_KEY,
   autoRefreshToken: true,
   persistSession: true,
   detectSessionInUrl: true,

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,6 +1,6 @@
 import { version } from './version'
 export const GOTRUE_URL = 'http://localhost:9999'
-export const STORAGE_KEY = 'supabase.auth.token'
+export const PERSISTENCE_KEY = 'supabase.auth.token'
 export const AUDIENCE = ''
 export const DEFAULT_HEADERS = { 'X-Client-Info': `gotrue-js/${version}` }
 export const EXPIRY_MARGIN = 10 // in seconds

--- a/src/lib/cookies.ts
+++ b/src/lib/cookies.ts
@@ -1,4 +1,4 @@
-import { AuthUnknownError } from "./errors"
+import { AuthUnknownError } from './errors'
 
 type Cookie = {
   name: string
@@ -114,7 +114,10 @@ function serialize(
  */
 function isSecureEnvironment(req: any) {
   if (!req || !req.headers || !req.headers.host) {
-    throw new AuthUnknownError('The "host" request header is not available', new Error('The "host" request header is not available'))
+    throw new AuthUnknownError(
+      'The "host" request header is not available',
+      new Error('The "host" request header is not available')
+    )
   }
 
   const host =

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -49,16 +49,12 @@ export const resolveResponse = async () => {
 }
 
 // LocalStorage helpers
-export const setItemAsync = async (
-  storage: SupportedStorage,
-  key: string,
-  data: any
-): Promise<void> => {
-  isBrowser() && (await storage?.setItem(key, JSON.stringify(data)))
+export const setItemAsync = async (storage: SupportedStorage, data: any): Promise<void> => {
+  isBrowser() && (await storage?.setItem(JSON.stringify(data)))
 }
 
-export const getItemAsync = async (storage: SupportedStorage, key: string): Promise<unknown> => {
-  const value = isBrowser() && (await storage?.getItem(key))
+export const getItemAsync = async (storage: SupportedStorage): Promise<unknown> => {
+  const value = isBrowser() && (await storage?.getItem())
   if (!value) return null
   try {
     return JSON.parse(value)
@@ -67,8 +63,8 @@ export const getItemAsync = async (storage: SupportedStorage, key: string): Prom
   }
 }
 
-export const removeItemAsync = async (storage: SupportedStorage, key: string): Promise<void> => {
-  isBrowser() && (await storage?.removeItem(key))
+export const removeItemAsync = async (storage: SupportedStorage): Promise<void> => {
+  isBrowser() && (await storage?.removeItem())
 }
 
 /**

--- a/src/lib/storage/localStorage.ts
+++ b/src/lib/storage/localStorage.ts
@@ -1,0 +1,35 @@
+type LocalStorageOptions = {
+  key: string
+}
+
+export interface CustomStorage {
+  /** The key used for saving the session */
+  readonly key: string
+  /** Returns the current session */
+  getItem(): string | null
+  /** Sets the current session */
+  setItem(value: string): void
+  /** Removes the current session */
+  removeItem(): void
+}
+
+export class LocalStorage implements CustomStorage {
+  readonly key: string
+  protected storage: Storage
+  constructor(options: LocalStorageOptions) {
+    this.key = options.key
+    this.storage = globalThis.localStorage
+  }
+
+  getItem(): string | null {
+    return this.storage.getItem(this.key)
+  }
+
+  setItem(value: string) {
+    return this.storage.setItem(this.key, value)
+  }
+
+  removeItem(): void {
+    return this.storage.removeItem(this.key)
+  }
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,4 +1,5 @@
-import { AuthError } from "./errors"
+import { AuthError } from './errors'
+import { CustomStorage } from './storage/localStorage'
 
 export type Provider =
   | 'apple'
@@ -26,25 +27,29 @@ export type AuthChangeEvent =
   | 'USER_UPDATED'
   | 'USER_DELETED'
 
-export type AuthResponse = {
-  user: User | null
-  session: Session | null
-  error: null
-} | {
-  user: null
-  session: null
-  error: AuthError
-} 
+export type AuthResponse =
+  | {
+      user: User | null
+      session: Session | null
+      error: null
+    }
+  | {
+      user: null
+      session: null
+      error: AuthError
+    }
 
-export type OAuthResponse = {
-  provider: Provider
-  url: string
-  error: null
-} | {
-  provider: Provider
-  url: null
-  error: AuthError
-}
+export type OAuthResponse =
+  | {
+      provider: Provider
+      url: string
+      error: null
+    }
+  | {
+      provider: Provider
+      url: null
+      error: AuthError
+    }
 export interface Session {
   provider_token?: string | null
   access_token: string
@@ -203,25 +208,29 @@ export interface UserCredentials {
   provider?: Provider
   oidc?: OpenIDConnectCredentials
 }
-export type SignInWithPasswordCredentials = {
-  email: string
-  password: string
-  options?: SignInWithPasswordOptions
-} | {
-  phone: string
-  password: string
-  options?: SignInWithPasswordOptions
-}
+export type SignInWithPasswordCredentials =
+  | {
+      email: string
+      password: string
+      options?: SignInWithPasswordOptions
+    }
+  | {
+      phone: string
+      password: string
+      options?: SignInWithPasswordOptions
+    }
 export interface SignInWithPasswordOptions {
   captchaToken?: string
 }
-export type SignInWithPasswordlessCredentials = {
-  email: string
-  options?: SignInWithPasswordlessOptions
-} | {
-  phone: string
-  options?: SignInWithPasswordlessOptions
-}
+export type SignInWithPasswordlessCredentials =
+  | {
+      email: string
+      options?: SignInWithPasswordlessOptions
+    }
+  | {
+      phone: string
+      options?: SignInWithPasswordlessOptions
+    }
 export interface SignInWithPasswordlessOptions {
   // The redirect url embedded in the email link
   emailRedirectTo?: string
@@ -271,7 +280,9 @@ type PromisifyMethods<T> = {
     : T[K]
 }
 
-export type SupportedStorage = PromisifyMethods<Pick<Storage, 'getItem' | 'setItem' | 'removeItem'>>
+export type SupportedStorage = PromisifyMethods<
+  Pick<CustomStorage, 'getItem' | 'setItem' | 'removeItem'>
+>
 
 export type CallRefreshTokenResult =
   | {

--- a/test/GoTrueClient.test.ts
+++ b/test/GoTrueClient.test.ts
@@ -78,7 +78,7 @@ describe('GoTrueClient', () => {
       }
 
       // wait 1 seconds before calling getSession()
-      await new Promise(r => setTimeout(r, 1000))
+      await new Promise((r) => setTimeout(r, 1000))
       const { session: userSession, error: userError } = await authWithSession.getSession()
 
       expect(userError).toBeNull()
@@ -100,8 +100,12 @@ describe('GoTrueClient', () => {
       expect(session).not.toBeNull()
 
       const [{ session: session1, error: error1 }, { session: session2, error: error2 }] =
-        // @ts-expect-error 'Allow access to private _callRefreshToken()'
-        await Promise.all([authWithSession._callRefreshToken(session?.refresh_token), authWithSession._callRefreshToken(session?.refresh_token)])
+        await Promise.all([
+          // @ts-expect-error 'Allow access to private _callRefreshToken()'
+          authWithSession._callRefreshToken(session?.refresh_token),
+          // @ts-expect-error 'Allow access to private _callRefreshToken()'
+          authWithSession._callRefreshToken(session?.refresh_token),
+        ])
 
       expect(error1).toBeNull()
       expect(error2).toBeNull()
@@ -171,13 +175,12 @@ describe('GoTrueClient', () => {
       expect(error).toBeNull()
       expect(session).not.toBeNull()
 
-      const [error1, error2] =
-        await Promise.allSettled([
-          // @ts-expect-error 'Allow access to private _callRefreshToken()'
-          authWithSession._callRefreshToken(session?.refresh_token),
-          // @ts-expect-error 'Allow access to private _callRefreshToken()'
-          authWithSession._callRefreshToken(session?.refresh_token),
-        ])
+      const [error1, error2] = await Promise.allSettled([
+        // @ts-expect-error 'Allow access to private _callRefreshToken()'
+        authWithSession._callRefreshToken(session?.refresh_token),
+        // @ts-expect-error 'Allow access to private _callRefreshToken()'
+        authWithSession._callRefreshToken(session?.refresh_token),
+      ])
 
       expect(error1.status).toEqual('rejected')
       expect(error2.status).toEqual('rejected')
@@ -528,43 +531,37 @@ describe('The auth client can signin with third-party oAuth providers', () => {
   })
 
   test('signIn() with Provider can append a redirectUrl ', async () => {
-    const { error, url, provider } = await auth.signInWithOAuth(
-      {
-        provider: 'google',
-        options: {
-          redirectTo: 'https://localhost:9000/welcome',
-        }
+    const { error, url, provider } = await auth.signInWithOAuth({
+      provider: 'google',
+      options: {
+        redirectTo: 'https://localhost:9000/welcome',
       },
-    )
+    })
     expect(error).toBeNull()
     expect(url).toBeTruthy()
     expect(provider).toBeTruthy()
   })
 
   test('signIn() with Provider can append scopes', async () => {
-    const { error, url, provider } = await auth.signInWithOAuth(
-      {
-        provider: 'github',
-        options: {
-          scopes: 'repo'
-        }
+    const { error, url, provider } = await auth.signInWithOAuth({
+      provider: 'github',
+      options: {
+        scopes: 'repo',
       },
-    )
+    })
     expect(error).toBeNull()
     expect(url).toBeTruthy()
     expect(provider).toBeTruthy()
   })
 
   test('signIn() with Provider can append multiple options', async () => {
-    const { error, url, provider } = await auth.signInWithOAuth(
-      {
-        provider: 'github',
-        options: {
-          redirectTo: 'https://localhost:9000/welcome',
-          scopes: 'repo',
-        }
+    const { error, url, provider } = await auth.signInWithOAuth({
+      provider: 'github',
+      options: {
+        redirectTo: 'https://localhost:9000/welcome',
+        scopes: 'repo',
       },
-    )
+    })
     expect(error).toBeNull()
     expect(url).toBeTruthy()
     expect(provider).toBeTruthy()


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Expose an interface where the developer can use their own custom storage option. Defaults to localstorage.
* Rename `localstorage` property to a more generic name - `storage` 
* Remove `storageKey` property
* Add custom storage interface and a `LocalStorage` class that implements the `CustomStorage` interface