### PR TITLE
feat: return types should always contain `data`

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -187,10 +187,10 @@ export default class GoTrueClient {
         user = data as User
       }
 
-      return { user, session, error: null }
+      return { data: { user, session }, error: null }
     } catch (error) {
       if (isAuthError(error)) {
-        return { user: null, session: null, error }
+        return { data: { user: null, session: null }, error }
       }
 
       throw error
@@ -227,7 +227,7 @@ export default class GoTrueClient {
       )
     } catch (error) {
       if (isAuthError(error)) {
-        return { user: null, session: null, error }
+        return { data: { user: null, session: null }, error }
       }
 
       throw error
@@ -269,7 +269,7 @@ export default class GoTrueClient {
           shouldCreateUser: options?.shouldCreateUser,
           captchaToken: options?.captchaToken,
         })
-        return { user: null, session: null, error }
+        return { data: { user: null, session: null }, error }
       }
       if ('phone' in credentials) {
         const { phone, options } = credentials
@@ -277,12 +277,12 @@ export default class GoTrueClient {
           shouldCreateUser: options?.shouldCreateUser,
           captchaToken: options?.captchaToken,
         })
-        return { user: null, session: null, error }
+        return { data: { user: null, session: null }, error }
       }
       throw new AuthInvalidCredentialsError('You must provide either an email or phone number.')
     } catch (error) {
       if (isAuthError(error)) {
-        return { user: null, session: null, error }
+        return { data: { user: null, session: null }, error }
       }
 
       throw error
@@ -330,10 +330,10 @@ export default class GoTrueClient {
         user = data as User
       }
 
-      return { user, session, error: null }
+      return { data: { user, session }, error: null }
     } catch (error) {
       if (isAuthError(error)) {
-        return { user: null, session: null, error }
+        return { data: { user: null, session: null }, error }
       }
 
       throw error
@@ -623,17 +623,17 @@ export default class GoTrueClient {
       const { data, error } = await this.api.signInWithEmail(email, password, {
         captchaToken: options.captchaToken,
       })
-      if (error || !data) return { user: null, session: null, error }
+      if (error || !data) return { data: { user: null, session: null }, error }
 
       if (data?.user?.confirmed_at || data?.user?.email_confirmed_at) {
         this._saveSession(data)
         this._notifyAllSubscribers('SIGNED_IN', data)
       }
 
-      return { user: data.user, session: data, error: null }
+      return { data: { user: data.user, session: data }, error: null }
     } catch (error) {
       if (isAuthError(error)) {
-        return { user: null, session: null, error }
+        return { data: { user: null, session: null }, error }
       }
 
       throw error
@@ -651,17 +651,17 @@ export default class GoTrueClient {
       const { session, error } = await this.api.signInWithPhone(phone, password, {
         captchaToken: options.captchaToken,
       })
-      if (error || !session) return { session: null, user: null, error }
+      if (error || !session) return { data: { session: null, user: null }, error }
 
       if (session?.user?.phone_confirmed_at) {
         this._saveSession(session)
         this._notifyAllSubscribers('SIGNED_IN', session)
       }
 
-      return { session, user: session.user, error: null }
+      return { data: { session, user: session.user }, error: null }
     } catch (error) {
       if (isAuthError(error)) {
-        return { session: null, user: null, error }
+        return { data: { session: null, user: null }, error }
       }
 
       throw error
@@ -685,7 +685,7 @@ export default class GoTrueClient {
     if (isBrowser()) {
       window.location.href = url
     }
-    return { provider, url, error: null }
+    return { data: { provider, url }, error: null }
   }
 
   private async _handleOpenIDConnectSignIn({

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,4 +1,4 @@
-import { AuthError } from "./errors"
+import { AuthError } from './errors'
 
 export type Provider =
   | 'apple'
@@ -26,25 +26,37 @@ export type AuthChangeEvent =
   | 'USER_UPDATED'
   | 'USER_DELETED'
 
-export type AuthResponse = {
-  user: User | null
-  session: Session | null
-  error: null
-} | {
-  user: null
-  session: null
-  error: AuthError
-} 
+export type AuthResponse =
+  | {
+      data: {
+        user: User | null
+        session: Session | null
+      }
+      error: null
+    }
+  | {
+      data: {
+        user: null
+        session: null
+      }
+      error: AuthError
+    }
 
-export type OAuthResponse = {
-  provider: Provider
-  url: string
-  error: null
-} | {
-  provider: Provider
-  url: null
-  error: AuthError
-}
+export type OAuthResponse =
+  | {
+      data: {
+        provider: Provider
+        url: string
+      }
+      error: null
+    }
+  | {
+      data: {
+        provider: Provider
+        url: null
+      }
+      error: AuthError
+    }
 export interface Session {
   provider_token?: string | null
   access_token: string
@@ -203,25 +215,29 @@ export interface UserCredentials {
   provider?: Provider
   oidc?: OpenIDConnectCredentials
 }
-export type SignInWithPasswordCredentials = {
-  email: string
-  password: string
-  options?: SignInWithPasswordOptions
-} | {
-  phone: string
-  password: string
-  options?: SignInWithPasswordOptions
-}
+export type SignInWithPasswordCredentials =
+  | {
+      email: string
+      password: string
+      options?: SignInWithPasswordOptions
+    }
+  | {
+      phone: string
+      password: string
+      options?: SignInWithPasswordOptions
+    }
 export interface SignInWithPasswordOptions {
   captchaToken?: string
 }
-export type SignInWithPasswordlessCredentials = {
-  email: string
-  options?: SignInWithPasswordlessOptions
-} | {
-  phone: string
-  options?: SignInWithPasswordlessOptions
-}
+export type SignInWithPasswordlessCredentials =
+  | {
+      email: string
+      options?: SignInWithPasswordlessOptions
+    }
+  | {
+      phone: string
+      options?: SignInWithPasswordlessOptions
+    }
 export interface SignInWithPasswordlessOptions {
   // The redirect url embedded in the email link
   emailRedirectTo?: string

--- a/test/GoTrueApi.test.ts
+++ b/test/GoTrueApi.test.ts
@@ -111,7 +111,10 @@ describe('GoTrueApi', () => {
 
     test('getUser() fetches a user by their access_token', async () => {
       const { email, password } = mockUserCredentials()
-      const { error: initialError, session } = await authClientWithSession.signUp({
+      const {
+        error: initialError,
+        data: { session },
+      } = await authClientWithSession.signUp({
         email,
         password,
       })
@@ -218,12 +221,13 @@ describe('GoTrueApi', () => {
 
     test('modify confirm email using updateUserById()', async () => {
       const { email, password } = mockUserCredentials()
-      const { error: createError, user } = await clientApiAutoConfirmOffSignupsEnabledClient.signUp(
-        {
-          email,
-          password,
-        }
-      )
+      const {
+        error: createError,
+        data: { user },
+      } = await clientApiAutoConfirmOffSignupsEnabledClient.signUp({
+        email,
+        password,
+      })
 
       expect(createError).toBeNull()
       expect(user).not.toBeUndefined()
@@ -336,7 +340,10 @@ describe('GoTrueApi', () => {
     test('resetPasswordForEmail() sends an email for password recovery', async () => {
       const { email, password } = mockUserCredentials()
 
-      const { error: initialError, session } = await authClientWithSession.signUp({
+      const {
+        error: initialError,
+        data: { session },
+      } = await authClientWithSession.signUp({
         email,
         password,
       })
@@ -368,7 +375,10 @@ describe('GoTrueApi', () => {
     test('refreshAccessToken()', async () => {
       const { email, password } = mockUserCredentials()
 
-      const { error: initialError, session } = await authClientWithSession.signUp({
+      const {
+        error: initialError,
+        data: { session },
+      } = await authClientWithSession.signUp({
         email,
         password,
       })
@@ -420,7 +430,10 @@ describe('GoTrueApi', () => {
       test('signOut() with an valid access token', async () => {
         const { email, password } = mockUserCredentials()
 
-        const { error: initialError, session } = await authClientWithSession.signUp({
+        const {
+          error: initialError,
+          data: { session },
+        } = await authClientWithSession.signUp({
           email,
           password,
         })
@@ -490,7 +503,10 @@ describe('GoTrueApi', () => {
       test('verifyOTP() with non-existent phone number', async () => {
         const { phone } = mockUserCredentials()
         const otp = mockVerificationOTP()
-        const { user, error } = await clientApiAutoConfirmDisabledClient.verifyOTP({
+        const {
+          data: { user },
+          error,
+        } = await clientApiAutoConfirmDisabledClient.verifyOTP({
           phone: `${phone}`,
           token: otp,
         })
@@ -502,7 +518,10 @@ describe('GoTrueApi', () => {
       test('verifyOTP() with invalid phone number', async () => {
         const { phone } = mockUserCredentials()
         const otp = mockVerificationOTP()
-        const { user, error } = await clientApiAutoConfirmDisabledClient.verifyOTP({
+        const {
+          data: { user },
+          error,
+        } = await clientApiAutoConfirmDisabledClient.verifyOTP({
           phone: `${phone}-invalid`,
           token: otp,
         })

--- a/test/GoTrueClient.test.ts
+++ b/test/GoTrueClient.test.ts
@@ -22,7 +22,10 @@ describe('GoTrueClient', () => {
     test('setSession should return no error', async () => {
       const { email, password } = mockUserCredentials()
 
-      const { error, session } = await authWithSession.signUp({
+      const {
+        error,
+        data: { session },
+      } = await authWithSession.signUp({
         email,
         password,
       })
@@ -39,7 +42,10 @@ describe('GoTrueClient', () => {
     test('getSession() should return the currentUser session', async () => {
       const { email, password } = mockUserCredentials()
 
-      const { error, session } = await authWithSession.signUp({
+      const {
+        error,
+        data: { session },
+      } = await authWithSession.signUp({
         email,
         password,
       })
@@ -58,7 +64,10 @@ describe('GoTrueClient', () => {
     test('getSession() should refresh the session and return a new access token', async () => {
       const { email, password } = mockUserCredentials()
 
-      const { error, session } = await authWithSession.signUp({
+      const {
+        error,
+        data: { session },
+      } = await authWithSession.signUp({
         email,
         password,
       })
@@ -78,7 +87,7 @@ describe('GoTrueClient', () => {
       }
 
       // wait 1 seconds before calling getSession()
-      await new Promise(r => setTimeout(r, 1000))
+      await new Promise((r) => setTimeout(r, 1000))
       const { session: userSession, error: userError } = await authWithSession.getSession()
 
       expect(userError).toBeNull()
@@ -91,7 +100,10 @@ describe('GoTrueClient', () => {
     test('refresh should only happen once', async () => {
       const { email, password } = mockUserCredentials()
 
-      const { error, session } = await authWithSession.signUp({
+      const {
+        error,
+        data: { session },
+      } = await authWithSession.signUp({
         email,
         password,
       })
@@ -100,8 +112,12 @@ describe('GoTrueClient', () => {
       expect(session).not.toBeNull()
 
       const [{ session: session1, error: error1 }, { session: session2, error: error2 }] =
-        // @ts-expect-error 'Allow access to private _callRefreshToken()'
-        await Promise.all([authWithSession._callRefreshToken(session?.refresh_token), authWithSession._callRefreshToken(session?.refresh_token)])
+        await Promise.all([
+          // @ts-expect-error 'Allow access to private _callRefreshToken()'
+          authWithSession._callRefreshToken(session?.refresh_token),
+          // @ts-expect-error 'Allow access to private _callRefreshToken()'
+          authWithSession._callRefreshToken(session?.refresh_token),
+        ])
 
       expect(error1).toBeNull()
       expect(error2).toBeNull()
@@ -124,7 +140,10 @@ describe('GoTrueClient', () => {
         })
       )
 
-      const { error, session } = await authWithSession.signUp({
+      const {
+        error,
+        data: { session },
+      } = await authWithSession.signUp({
         email,
         password,
       })
@@ -163,7 +182,10 @@ describe('GoTrueClient', () => {
       const { email, password } = mockUserCredentials()
       refreshAccessTokenSpy.mockImplementationOnce(() => Promise.reject(mockError))
 
-      const { error, session } = await authWithSession.signUp({
+      const {
+        error,
+        data: { session },
+      } = await authWithSession.signUp({
         email,
         password,
       })
@@ -171,13 +193,12 @@ describe('GoTrueClient', () => {
       expect(error).toBeNull()
       expect(session).not.toBeNull()
 
-      const [error1, error2] =
-        await Promise.allSettled([
-          // @ts-expect-error 'Allow access to private _callRefreshToken()'
-          authWithSession._callRefreshToken(session?.refresh_token),
-          // @ts-expect-error 'Allow access to private _callRefreshToken()'
-          authWithSession._callRefreshToken(session?.refresh_token),
-        ])
+      const [error1, error2] = await Promise.allSettled([
+        // @ts-expect-error 'Allow access to private _callRefreshToken()'
+        authWithSession._callRefreshToken(session?.refresh_token),
+        // @ts-expect-error 'Allow access to private _callRefreshToken()'
+        authWithSession._callRefreshToken(session?.refresh_token),
+      ])
 
       expect(error1.status).toEqual('rejected')
       expect(error2.status).toEqual('rejected')
@@ -209,7 +230,10 @@ describe('GoTrueClient', () => {
   test('signUp() with email', async () => {
     const { email, password } = mockUserCredentials()
 
-    const { error, session, user } = await auth.signUp({
+    const {
+      error,
+      data: { session, user },
+    } = await auth.signUp({
       email,
       password,
     })
@@ -225,7 +249,10 @@ describe('GoTrueClient', () => {
     test('signUp() when phone sign up missing provider account', async () => {
       const { phone, password } = mockUserCredentials()
 
-      const { error, session, user } = await phoneClient.signUp({
+      const {
+        error,
+        data: { session, user },
+      } = await phoneClient.signUp({
         phone,
         password,
       })
@@ -240,7 +267,10 @@ describe('GoTrueClient', () => {
     test('signUp() with phone', async () => {
       const { phone, password } = mockUserCredentials()
 
-      const { error, session, user } = await phoneClient.signUp({
+      const {
+        error,
+        data: { session, user },
+      } = await phoneClient.signUp({
         phone,
         password,
       })
@@ -266,7 +296,10 @@ describe('GoTrueClient', () => {
     })
 
     // sign up again
-    const { error, session, user } = await auth.signUp({
+    const {
+      error,
+      data: { session, user },
+    } = await auth.signUp({
       email,
       password,
     })
@@ -285,7 +318,10 @@ describe('GoTrueClient', () => {
       password,
     })
 
-    const { error, session, user } = await auth.signInWithPassword({
+    const {
+      error,
+      data: { session, user },
+    } = await auth.signInWithPassword({
       email,
       password,
     })
@@ -329,7 +365,10 @@ describe('GoTrueClient', () => {
   test('signIn() with refreshToken', async () => {
     const { email, password } = mockUserCredentials()
 
-    const { error: initialError, session: initialSession } = await authWithSession.signUp({
+    const {
+      error: initialError,
+      data: { session: initialSession },
+    } = await authWithSession.signUp({
       email,
       password,
     })
@@ -337,7 +376,6 @@ describe('GoTrueClient', () => {
     expect(initialError).toBeNull()
     expect(initialSession).not.toBeNull()
 
-    const refreshToken = initialSession?.refresh_token
     const { session, error } = await authWithSession.getSession()
 
     expect(error).toBeNull()
@@ -401,7 +439,9 @@ describe('User management', () => {
   test('Get user', async () => {
     const { email, password } = mockUserCredentials()
 
-    const { session } = await authWithSession.signUp({
+    const {
+      data: { session },
+    } = await authWithSession.signUp({
       email,
       password,
     })
@@ -490,7 +530,9 @@ describe('User management', () => {
       password,
     })
 
-    const { user } = await authWithSession.signInWithPassword({
+    const {
+      data: { user },
+    } = await authWithSession.signInWithPassword({
       email,
       password,
     })
@@ -506,7 +548,10 @@ describe('User management', () => {
   test('signIn() with the wrong password', async () => {
     const { email, password } = mockUserCredentials()
 
-    const { error, session } = await auth.signInWithPassword({
+    const {
+      error,
+      data: { session },
+    } = await auth.signInWithPassword({
       email,
       password: password + '-wrong',
     })
@@ -519,7 +564,10 @@ describe('User management', () => {
 
 describe('The auth client can signin with third-party oAuth providers', () => {
   test('signIn() with Provider', async () => {
-    const { error, url, provider } = await auth.signInWithOAuth({
+    const {
+      error,
+      data: { url, provider },
+    } = await auth.signInWithOAuth({
       provider: 'google',
     })
     expect(error).toBeNull()
@@ -528,43 +576,46 @@ describe('The auth client can signin with third-party oAuth providers', () => {
   })
 
   test('signIn() with Provider can append a redirectUrl ', async () => {
-    const { error, url, provider } = await auth.signInWithOAuth(
-      {
-        provider: 'google',
-        options: {
-          redirectTo: 'https://localhost:9000/welcome',
-        }
+    const {
+      error,
+      data: { url, provider },
+    } = await auth.signInWithOAuth({
+      provider: 'google',
+      options: {
+        redirectTo: 'https://localhost:9000/welcome',
       },
-    )
+    })
     expect(error).toBeNull()
     expect(url).toBeTruthy()
     expect(provider).toBeTruthy()
   })
 
   test('signIn() with Provider can append scopes', async () => {
-    const { error, url, provider } = await auth.signInWithOAuth(
-      {
-        provider: 'github',
-        options: {
-          scopes: 'repo'
-        }
+    const {
+      error,
+      data: { url, provider },
+    } = await auth.signInWithOAuth({
+      provider: 'github',
+      options: {
+        scopes: 'repo',
       },
-    )
+    })
     expect(error).toBeNull()
     expect(url).toBeTruthy()
     expect(provider).toBeTruthy()
   })
 
   test('signIn() with Provider can append multiple options', async () => {
-    const { error, url, provider } = await auth.signInWithOAuth(
-      {
-        provider: 'github',
-        options: {
-          redirectTo: 'https://localhost:9000/welcome',
-          scopes: 'repo',
-        }
+    const {
+      error,
+      data: { url, provider },
+    } = await auth.signInWithOAuth({
+      provider: 'github',
+      options: {
+        redirectTo: 'https://localhost:9000/welcome',
+        scopes: 'repo',
       },
-    )
+    })
     expect(error).toBeNull()
     expect(url).toBeTruthy()
     expect(provider).toBeTruthy()
@@ -592,7 +643,10 @@ describe('The auth client can signin with third-party oAuth providers', () => {
     test('User can sign up', async () => {
       const { email, password } = mockUserCredentials()
 
-      const { error, user } = await signUpEnabledClient.signUp({
+      const {
+        error,
+        data: { user },
+      } = await signUpEnabledClient.signUp({
         email,
         password,
       })
@@ -608,7 +662,10 @@ describe('The auth client can signin with third-party oAuth providers', () => {
     test('User cannot sign up', async () => {
       const { email, password } = mockUserCredentials()
 
-      const { error, user } = await signUpDisabledClient.signUp({
+      const {
+        error,
+        data: { user },
+      } = await signUpDisabledClient.signUp({
         email,
         password,
       })


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Common methods should always return an object with `{ data: {...}, error: ... }` 
