### PR TITLE
fix: export errors

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,3 +3,4 @@ import GoTrueClient from './GoTrueClient'
 
 export { GoTrueApi, GoTrueClient }
 export * from './lib/types'
+export * from './lib/errors'


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Errors are not currently exported by the library.

## What is the new behavior?

Errors are exported to match the other libraries, for example `storage-js`: https://github.com/supabase/storage-js/blob/next/src/index.ts#L3
