### PR TITLE
fix: refactor return types

### DIFF
--- a/src/GoTrueApi.ts
+++ b/src/GoTrueApi.ts
@@ -8,6 +8,7 @@ import {
   User,
   UserAttributes,
   VerifyOTPParams,
+  UserResponse,
 } from './lib/types'
 import { AuthError, isAuthError } from './lib/errors'
 
@@ -803,21 +804,15 @@ export default class GoTrueApi {
    *
    * @param jwt A valid, logged-in JWT. Typically, the access_token for the currentSession
    */
-  async getUser(jwt: string): Promise<
-    | {
-        user: User
-        error: null
-      }
-    | { user: null; error: AuthError }
-  > {
+  async getUser(jwt: string): Promise<UserResponse> {
     try {
       const user: User = await get(this.fetch, `${this.url}/user`, {
         headers: this._createRequestHeaders(jwt),
       })
-      return { user, error: null }
+      return { data: { user }, error: null }
     } catch (error) {
       if (isAuthError(error)) {
-        return { user: null, error }
+        return { data: { user: null }, error }
       }
 
       throw error
@@ -829,26 +824,16 @@ export default class GoTrueApi {
    * @param jwt A valid, logged-in JWT.
    * @param attributes The data you want to update.
    */
-  async updateUser(
-    jwt: string,
-    attributes: UserAttributes
-  ): Promise<
-    | {
-        user: User
-        error: null
-      }
-    | { user: null; error: AuthError }
-  > {
+  async updateUser(jwt: string, attributes: UserAttributes): Promise<UserResponse> {
     try {
       const user: User = await put(this.fetch, `${this.url}/user`, attributes, {
         headers: this._createRequestHeaders(jwt),
       })
-      return { user, error: null }
+      return { data: { user }, error: null }
     } catch (error) {
       if (isAuthError(error)) {
-        return { user: null, error }
+        return { data: { user: null }, error }
       }
-
       throw error
     }
   }

--- a/src/GoTrueApi.ts
+++ b/src/GoTrueApi.ts
@@ -411,49 +411,6 @@ export default class GoTrueApi {
   }
 
   /**
-   * @deprecated Use `verifyOTP` instead!
-   * @param phone The user's phone number WITH international prefix
-   * @param token token that user was sent to their mobile phone
-   * @param options.redirectTo A URL or mobile address to send the user to after they are confirmed.
-   */
-  async verifyMobileOTP(
-    phone: string,
-    token: string,
-    options: {
-      redirectTo?: string
-    } = {}
-  ): Promise<
-    | {
-        data: User
-        error: null
-      }
-    | {
-        data: Session
-        error: null
-      }
-    | { data: null; error: AuthError }
-  > {
-    try {
-      const headers = { ...this.headers }
-      const data = await post(
-        this.fetch,
-        `${this.url}/verify`,
-        { phone, token, type: 'sms', redirect_to: options.redirectTo },
-        { headers }
-      )
-      const session = { ...data }
-      if (session.expires_in) session.expires_at = expiresAt(data.expires_in)
-      return { data: session, error: null }
-    } catch (error) {
-      if (isAuthError(error)) {
-        return { data: null, error }
-      }
-
-      throw error
-    }
-  }
-
-  /**
    * Send User supplied Email / Mobile OTP to be verified
    * @param email The user's email address
    * @param phone The user's phone number WITH international prefix

--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -411,6 +411,7 @@ export default class GoTrueClient {
 
   /**
    * Updates user data, if there is a logged in user.
+   * @param attributes The data you want to update.
    */
   async update(attributes: UserAttributes): Promise<UserResponse> {
     try {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -57,6 +57,21 @@ export type OAuthResponse =
       }
       error: AuthError
     }
+
+export type UserResponse =
+  | {
+      data: {
+        user: User
+      }
+      error: null
+    }
+  | {
+      data: {
+        user: null
+      }
+      error: AuthError
+    }
+
 export interface Session {
   provider_token?: string | null
   access_token: string

--- a/test/GoTrueApi.test.ts
+++ b/test/GoTrueApi.test.ts
@@ -124,7 +124,10 @@ describe('GoTrueApi', () => {
 
       const jwt = session?.access_token || ''
 
-      const { error, user } = await serviceRoleApiClient.getUser(jwt)
+      const {
+        error,
+        data: { user },
+      } = await serviceRoleApiClient.getUser(jwt)
 
       expect(error).toBeNull()
       expect(user).not.toBeUndefined()

--- a/test/GoTrueApi.test.ts
+++ b/test/GoTrueApi.test.ts
@@ -111,18 +111,15 @@ describe('GoTrueApi', () => {
 
     test('getUser() fetches a user by their access_token', async () => {
       const { email, password } = mockUserCredentials()
-      const {
-        error: initialError,
-        data: { session },
-      } = await authClientWithSession.signUp({
+      const { error: initialError, data } = await authClientWithSession.signUp({
         email,
         password,
       })
 
       expect(initialError).toBeNull()
-      expect(session).not.toBeNull()
+      expect(data.session).not.toBeNull()
 
-      const jwt = session?.access_token || ''
+      const jwt = data.session?.access_token || ''
 
       const {
         error,
@@ -339,16 +336,13 @@ describe('GoTrueApi', () => {
     test('resetPasswordForEmail() sends an email for password recovery', async () => {
       const { email, password } = mockUserCredentials()
 
-      const {
-        error: initialError,
-        data: { session },
-      } = await authClientWithSession.signUp({
+      const { error: initialError, data } = await authClientWithSession.signUp({
         email,
         password,
       })
 
       expect(initialError).toBeNull()
-      expect(session).not.toBeNull()
+      expect(data.session).not.toBeNull()
 
       const redirectTo = 'http://localhost:9999/welcome'
       const { error, data: user } = await serviceRoleApiClient.resetPasswordForEmail(email, {
@@ -374,10 +368,7 @@ describe('GoTrueApi', () => {
     test('refreshAccessToken()', async () => {
       const { email, password } = mockUserCredentials()
 
-      const {
-        error: initialError,
-        data: { session },
-      } = await authClientWithSession.signUp({
+      const { error: initialError, data } = await authClientWithSession.signUp({
         email,
         password,
       })
@@ -385,7 +376,7 @@ describe('GoTrueApi', () => {
       expect(initialError).toBeNull()
 
       const { error, session: refreshedSession } = await serviceRoleApiClient.refreshAccessToken(
-        session?.refresh_token || ''
+        data.session?.refresh_token || ''
       )
 
       const user = refreshedSession?.user
@@ -429,18 +420,15 @@ describe('GoTrueApi', () => {
       test('signOut() with an valid access token', async () => {
         const { email, password } = mockUserCredentials()
 
-        const {
-          error: initialError,
-          data: { session },
-        } = await authClientWithSession.signUp({
+        const { error: initialError, data } = await authClientWithSession.signUp({
           email,
           password,
         })
 
         expect(initialError).toBeNull()
-        expect(session).not.toBeNull()
+        expect(data.session).not.toBeNull()
 
-        const { error } = await serviceRoleApiClient.signOut(session?.access_token || '')
+        const { error } = await serviceRoleApiClient.signOut(data.session?.access_token || '')
         expect(error).toBeNull()
       })
 

--- a/test/GoTrueClient.test.ts
+++ b/test/GoTrueClient.test.ts
@@ -23,23 +23,20 @@ describe('GoTrueClient', () => {
     test('setSession should return no error', async () => {
       const { email, password } = mockUserCredentials()
 
-      const {
-        error,
-        data: { session },
-      } = await authWithSession.signUp({
+      const { error, data } = await authWithSession.signUp({
         email,
         password,
       })
       expect(error).toBeNull()
-      expect(session).not.toBeNull()
+      expect(data.session).not.toBeNull()
 
-      await authWithSession.setSession(session?.refresh_token as string)
+      await authWithSession.setSession(data.session?.refresh_token as string)
       const {
         data: { user },
         error: updateError,
       } = await authWithSession.update({ data: { hello: 'world' } })
 
-      expect(updateError).not.toBeNull()
+      expect(updateError).toBeNull()
       expect(user).not.toBeNull()
       expect(user?.user_metadata).toStrictEqual({ hello: 'world' })
     })
@@ -47,16 +44,13 @@ describe('GoTrueClient', () => {
     test('getSession() should return the currentUser session', async () => {
       const { email, password } = mockUserCredentials()
 
-      const {
-        error,
-        data: { session },
-      } = await authWithSession.signUp({
+      const { error, data } = await authWithSession.signUp({
         email,
         password,
       })
 
       expect(error).toBeNull()
-      expect(session).not.toBeNull()
+      expect(data.session).not.toBeNull()
 
       const { session: userSession, error: userError } = await authWithSession.getSession()
 
@@ -69,16 +63,13 @@ describe('GoTrueClient', () => {
     test('getSession() should refresh the session and return a new access token', async () => {
       const { email, password } = mockUserCredentials()
 
-      const {
-        error,
-        data: { session },
-      } = await authWithSession.signUp({
+      const { error, data } = await authWithSession.signUp({
         email,
         password,
       })
 
       expect(error).toBeNull()
-      expect(session).not.toBeNull()
+      expect(data.session).not.toBeNull()
 
       const expired = new Date()
       expired.setMinutes(expired.getMinutes() - 1)
@@ -99,29 +90,26 @@ describe('GoTrueClient', () => {
       expect(userSession).not.toBeNull()
       expect(userSession).toHaveProperty('access_token')
       expect(refreshAccessTokenSpy).toBeCalledTimes(1)
-      expect(session!.access_token).not.toEqual(userSession!.access_token)
+      expect(data.session?.access_token).not.toEqual(userSession?.access_token)
     })
 
     test('refresh should only happen once', async () => {
       const { email, password } = mockUserCredentials()
 
-      const {
-        error,
-        data: { session },
-      } = await authWithSession.signUp({
+      const { error, data } = await authWithSession.signUp({
         email,
         password,
       })
 
       expect(error).toBeNull()
-      expect(session).not.toBeNull()
+      expect(data.session).not.toBeNull()
 
       const [{ session: session1, error: error1 }, { session: session2, error: error2 }] =
         await Promise.all([
           // @ts-expect-error 'Allow access to private _callRefreshToken()'
-          authWithSession._callRefreshToken(session?.refresh_token),
+          authWithSession._callRefreshToken(data.session?.refresh_token),
           // @ts-expect-error 'Allow access to private _callRefreshToken()'
-          authWithSession._callRefreshToken(session?.refresh_token),
+          authWithSession._callRefreshToken(data.session?.refresh_token),
         ])
 
       expect(error1).toBeNull()
@@ -131,7 +119,7 @@ describe('GoTrueClient', () => {
 
       // if both have the same access token, we can assume that they are
       // the result of the same refresh
-      expect(session1!.access_token).toEqual(session2!.access_token)
+      expect(session1?.access_token).toEqual(session2?.access_token)
 
       expect(refreshAccessTokenSpy).toBeCalledTimes(1)
     })
@@ -145,23 +133,20 @@ describe('GoTrueClient', () => {
         })
       )
 
-      const {
-        error,
-        data: { session },
-      } = await authWithSession.signUp({
+      const { error, data } = await authWithSession.signUp({
         email,
         password,
       })
 
       expect(error).toBeNull()
-      expect(session).not.toBeNull()
+      expect(data.session).not.toBeNull()
 
       const [{ session: session1, error: error1 }, { session: session2, error: error2 }] =
         await Promise.all([
           // @ts-expect-error 'Allow access to private _callRefreshToken()'
-          authWithSession._callRefreshToken(session?.refresh_token),
+          authWithSession._callRefreshToken(data.session?.refresh_token),
           // @ts-expect-error 'Allow access to private _callRefreshToken()'
-          authWithSession._callRefreshToken(session?.refresh_token),
+          authWithSession._callRefreshToken(data.session?.refresh_token),
         ])
 
       expect(error1).toHaveProperty('message')
@@ -174,7 +159,7 @@ describe('GoTrueClient', () => {
       // verify the deferred has been reset and successive calls can be made
       // @ts-expect-error 'Allow access to private _callRefreshToken()'
       const { session: session3, error: error3 } = await authWithSession._callRefreshToken(
-        session!.refresh_token
+        data.session!.refresh_token
       )
 
       expect(error3).toBeNull()
@@ -187,22 +172,19 @@ describe('GoTrueClient', () => {
       const { email, password } = mockUserCredentials()
       refreshAccessTokenSpy.mockImplementationOnce(() => Promise.reject(mockError))
 
-      const {
-        error,
-        data: { session },
-      } = await authWithSession.signUp({
+      const { error, data } = await authWithSession.signUp({
         email,
         password,
       })
 
       expect(error).toBeNull()
-      expect(session).not.toBeNull()
+      expect(data.session).not.toBeNull()
 
       const [error1, error2] = await Promise.allSettled([
         // @ts-expect-error 'Allow access to private _callRefreshToken()'
-        authWithSession._callRefreshToken(session?.refresh_token),
+        authWithSession._callRefreshToken(data.session?.refresh_token),
         // @ts-expect-error 'Allow access to private _callRefreshToken()'
-        authWithSession._callRefreshToken(session?.refresh_token),
+        authWithSession._callRefreshToken(data.session?.refresh_token),
       ])
 
       expect(error1.status).toEqual('rejected')
@@ -217,7 +199,7 @@ describe('GoTrueClient', () => {
       // vreify the deferred has been reset and successive calls can be made
       // @ts-expect-error 'Allow access to private _callRefreshToken()'
       const { session: session3, error: error3 } = await authWithSession._callRefreshToken(
-        session!.refresh_token
+        data.session!.refresh_token
       )
 
       expect(error3).toBeNull()
@@ -235,36 +217,30 @@ describe('GoTrueClient', () => {
   test('signUp() with email', async () => {
     const { email, password } = mockUserCredentials()
 
-    const {
-      error,
-      data: { session, user },
-    } = await auth.signUp({
+    const { error, data } = await auth.signUp({
       email,
       password,
     })
 
     expect(error).toBeNull()
-    expect(session).not.toBeNull()
-    expect(user).not.toBeNull()
+    expect(data.session).not.toBeNull()
+    expect(data.user).not.toBeNull()
 
-    expect(user?.email).toEqual(email)
+    expect(data.user?.email).toEqual(email)
   })
 
   describe('Phone OTP Auth', () => {
     test('signUp() when phone sign up missing provider account', async () => {
       const { phone, password } = mockUserCredentials()
 
-      const {
-        error,
-        data: { session, user },
-      } = await phoneClient.signUp({
+      const { error, data } = await phoneClient.signUp({
         phone,
         password,
       })
 
       expect(error).not.toBeNull()
-      expect(session).toBeNull()
-      expect(user).toBeNull()
+      expect(data.session).toBeNull()
+      expect(data.user).toBeNull()
 
       expect(error?.message).toEqual('Error sending confirmation sms: Missing Twilio account SID')
     })
@@ -272,19 +248,14 @@ describe('GoTrueClient', () => {
     test('signUp() with phone', async () => {
       const { phone, password } = mockUserCredentials()
 
-      const {
-        error,
-        data: { session, user },
-      } = await phoneClient.signUp({
+      const { error, data } = await phoneClient.signUp({
         phone,
         password,
       })
 
       expect(error).not.toBeNull()
-      expect(session).toBeNull()
-      expect(user).toBeNull()
-
-      // expect(user?.phone).toEqual(phone)
+      expect(data.session).toBeNull()
+      expect(data.user).toBeNull()
     })
 
     test('verifyOTP()', async () => {
@@ -301,16 +272,13 @@ describe('GoTrueClient', () => {
     })
 
     // sign up again
-    const {
-      error,
-      data: { session, user },
-    } = await auth.signUp({
+    const { error, data } = await auth.signUp({
       email,
       password,
     })
 
-    expect(session).toBeNull()
-    expect(user).toBeNull()
+    expect(data.session).toBeNull()
+    expect(data.user).toBeNull()
 
     expect(error?.message).toMatch(/^User already registered/)
   })
@@ -323,16 +291,13 @@ describe('GoTrueClient', () => {
       password,
     })
 
-    const {
-      error,
-      data: { session, user },
-    } = await auth.signInWithPassword({
+    const { error, data } = await auth.signInWithPassword({
       email,
       password,
     })
 
     expect(error).toBeNull()
-    expect(session).toMatchObject({
+    expect(data.session).toMatchObject({
       access_token: expect.any(String),
       refresh_token: expect.any(String),
       expires_in: expect.any(Number),
@@ -351,7 +316,7 @@ describe('GoTrueClient', () => {
         },
       },
     })
-    expect(user).toMatchObject({
+    expect(data.user).toMatchObject({
       id: expect.any(String),
       email: expect.any(String),
       phone: expect.any(String),
@@ -364,21 +329,19 @@ describe('GoTrueClient', () => {
         provider: 'email',
       },
     })
-    expect(user?.email).toBe(email)
+    expect(data.user?.email).toBe(email)
   })
 
   test('signIn() with refreshToken', async () => {
     const { email, password } = mockUserCredentials()
 
-    const {
-      error: initialError,
-      data: { session: initialSession },
-    } = await authWithSession.signUp({
+    const { error: initialError, data } = await authWithSession.signUp({
       email,
       password,
     })
 
     expect(initialError).toBeNull()
+    const initialSession = data.session
     expect(initialSession).not.toBeNull()
 
     const { session, error } = await authWithSession.getSession()
@@ -444,14 +407,12 @@ describe('User management', () => {
   test('Get user', async () => {
     const { email, password } = mockUserCredentials()
 
-    const {
-      data: { session },
-    } = await authWithSession.signUp({
+    const { data } = await authWithSession.signUp({
       email,
       password,
     })
 
-    expect(session?.user).toMatchObject({
+    expect(data.user).toMatchObject({
       id: expect.any(String),
       email: expect.any(String),
       phone: expect.any(String),
@@ -465,7 +426,7 @@ describe('User management', () => {
       },
     })
 
-    expect(session?.user?.email).toBe(email)
+    expect(data.user?.email).toBe(email)
   })
 
   test('Update user', async () => {
@@ -559,17 +520,14 @@ describe('User management', () => {
   test('signIn() with the wrong password', async () => {
     const { email, password } = mockUserCredentials()
 
-    const {
-      error,
-      data: { session },
-    } = await auth.signInWithPassword({
+    const { error, data } = await auth.signInWithPassword({
       email,
       password: password + '-wrong',
     })
 
     expect(error).not.toBeNull()
     expect(error?.message).not.toBeNull()
-    expect(session).toBeNull()
+    expect(data.session).toBeNull()
   })
 })
 

--- a/test/GoTrueClient.test.ts
+++ b/test/GoTrueClient.test.ts
@@ -1,3 +1,4 @@
+import { User } from '../src'
 import { AuthError } from '../src/lib/errors'
 import {
   authClient as auth,
@@ -33,8 +34,12 @@ describe('GoTrueClient', () => {
       expect(session).not.toBeNull()
 
       await authWithSession.setSession(session?.refresh_token as string)
-      const { user } = await authWithSession.update({ data: { hello: 'world' } })
+      const {
+        data: { user },
+        error: updateError,
+      } = await authWithSession.update({ data: { hello: 'world' } })
 
+      expect(updateError).not.toBeNull()
       expect(user).not.toBeNull()
       expect(user?.user_metadata).toStrictEqual({ hello: 'world' })
     })
@@ -473,7 +478,10 @@ describe('User management', () => {
 
     const userMetadata = { hello: 'world' }
 
-    const { error, user } = await authWithSession.update({ data: userMetadata })
+    const {
+      error,
+      data: { user },
+    } = await authWithSession.update({ data: userMetadata })
 
     expect(error).toBeNull()
     expect(user).toMatchObject({
@@ -505,7 +513,10 @@ describe('User management', () => {
 
     const userMetadata = { hello: 'world' }
 
-    const { user, error } = await authWithSession.update({ data: userMetadata })
+    const {
+      data: { user },
+      error,
+    } = await authWithSession.update({ data: userMetadata })
 
     expect(error).toBeNull()
     expect(user).toMatchObject({


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Return `{ data, error }` for more methods like `getUser` and `updateUser` 
* Differentiate `auth.getUser` and `auth.api.getUser` by renaming the former to `auth.getUserFromSession` 
* Remove `verifyMobileOTP`  