### PR TITLE
feat: update signIn methods, getUser and getSession

### DIFF
--- a/src/GoTrueAdminApi.ts
+++ b/src/GoTrueAdminApi.ts
@@ -1,6 +1,6 @@
 import { Fetch, _request, _userResponse } from './lib/fetch'
 import { resolveFetch } from './lib/helpers'
-import { AdminUserAttributes, Session, User, UserResponse } from './lib/types'
+import { AdminUserAttributes, GenerateLinkTypes, Session, User, UserResponse } from './lib/types'
 import { AuthError, isAuthError } from './lib/errors'
 
 export default class GoTrueAdminApi {
@@ -84,13 +84,7 @@ export default class GoTrueAdminApi {
    * @param options.redirectTo The redirect url which should be appended to the generated link
    */
   async generateLink(
-    type:
-      | 'signup'
-      | 'magiclink'
-      | 'recovery'
-      | 'invite'
-      | 'email_change_current'
-      | 'email_change_new',
+    type: GenerateLinkTypes,
     email: string,
     options: {
       password?: string

--- a/src/GoTrueAdminApi.ts
+++ b/src/GoTrueAdminApi.ts
@@ -81,7 +81,7 @@ export default class GoTrueAdminApi {
    * @param email The user's email.
    * @param options.password User password. For signup only.
    * @param options.data Optional user metadata. For signup only.
-   * @param options.redirectTo The link type ("signup" or "magiclink" or "recovery" or "invite").
+   * @param options.redirectTo The redirect url which should be appended to the generated link
    */
   async generateLink(
     type:

--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -372,7 +372,7 @@ export default class GoTrueClient {
       const session: Session | null = data.session
       const user: User = data.user
 
-      if ((data as Session).access_token) {
+      if (session?.access_token) {
         this._saveSession(session as Session)
         this._notifyAllSubscribers('SIGNED_IN', session)
       }

--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -43,7 +43,7 @@ import type {
   UserAttributes,
   UserCredentials,
   UserResponse,
-  VerifyOTPParams,
+  VerifyOtpParams,
 } from './lib/types'
 
 polyfillGlobalThis() // Make "globalThis" available
@@ -334,7 +334,7 @@ export default class GoTrueClient {
   }
 
   /**
-   * Log in a user given a User supplied OTP received via mobile.
+   * Log in a user given a User supplied Otp received via mobile.
    * @param email The user's email address.
    * @param phone The user's phone number.
    * @param token The user's password.
@@ -342,8 +342,8 @@ export default class GoTrueClient {
    * @param options.redirectTo A URL to send the user to after they are confirmed.
    * @param options.captchaToken An optional captcha verification token.
    */
-  async verifyOTP(
-    params: VerifyOTPParams,
+  async verifyOtp(
+    params: VerifyOtpParams,
     options: {
       redirectTo?: string
       captchaToken?: string

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -74,7 +74,14 @@ export type UserResponse =
 
 export interface Session {
   provider_token?: string | null
+  /**
+   * The access token jwt. It is recommended to set the JWT_EXPIRY to a shorter expiry value.
+   */
   access_token: string
+  /**
+   * A one-time used refresh token that never expires.
+   */
+  refresh_token: string
   /**
    * The number of seconds until the token expires (since it was issued). Returned when a login is confirmed.
    */
@@ -83,7 +90,6 @@ export interface Session {
    * A timestamp of when the token will expire. Returned when a login is confirmed.
    */
   expires_at?: number
-  refresh_token: string
   token_type: string
   user: User
 }
@@ -164,7 +170,7 @@ export interface AdminUserAttributes extends UserAttributes {
    * Only a service role can modify.
    *
    * Note: When using the GoTrueAdminApi and wanting to modify a user's user_metadata,
-   * this attribute is used instead of UserAttributes data.
+   * this attribute is used instead of UserAttributes.data.
    *
    */
   user_metadata?: object
@@ -272,6 +278,13 @@ export interface VerifyEmailOtpParams {
 }
 export type MobileOtpType = 'sms' | 'phone_change'
 export type EmailOtpType = 'signup' | 'invite' | 'magiclink' | 'recovery' | 'email_change'
+export type GenerateLinkTypes =
+  | 'signup'
+  | 'invite'
+  | 'magiclink'
+  | 'recovery'
+  | 'email_change_current'
+  | 'email_change_new'
 
 export interface OpenIDConnectCredentials {
   id_token: string

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -257,21 +257,21 @@ export interface SignInWithOAuthOptions {
   queryParams?: { [key: string]: string }
 }
 
-export type VerifyOTPParams = VerifyMobileOTPParams | VerifyEmailOTPParams
-export interface VerifyMobileOTPParams {
+export type VerifyOtpParams = VerifyMobileOtpParams | VerifyEmailOtpParams
+export interface VerifyMobileOtpParams {
   email?: undefined
   phone: string
   token: string
-  type: MobileOTPType
+  type: MobileOtpType
 }
-export interface VerifyEmailOTPParams {
+export interface VerifyEmailOtpParams {
   email: string
   phone?: undefined
   token: string
-  type: EmailOTPType
+  type: EmailOtpType
 }
-export type MobileOTPType = 'sms' | 'phone_change'
-export type EmailOTPType = 'signup' | 'invite' | 'magiclink' | 'recovery' | 'email_change'
+export type MobileOtpType = 'sms' | 'phone_change'
+export type EmailOtpType = 'signup' | 'invite' | 'magiclink' | 'recovery' | 'email_change'
 
 export interface OpenIDConnectCredentials {
   id_token: string

--- a/test/GoTrueApi.test.ts
+++ b/test/GoTrueApi.test.ts
@@ -329,15 +329,15 @@ describe('GoTrueAdminApi', () => {
     })
   })
 
-  describe('Email/Phone OTP Verification', () => {
-    describe('GoTrueClient verifyOTP()', () => {
-      test('verifyOTP() with non-existent phone number', async () => {
+  describe('Email/Phone Otp Verification', () => {
+    describe('GoTrueClient verifyOtp()', () => {
+      test('verifyOtp() with non-existent phone number', async () => {
         const { phone } = mockUserCredentials()
         const otp = mockVerificationOTP()
         const {
           data: { user },
           error,
-        } = await clientApiAutoConfirmDisabledClient.verifyOTP({
+        } = await clientApiAutoConfirmDisabledClient.verifyOtp({
           phone: `${phone}`,
           token: otp,
           type: 'sms',
@@ -353,7 +353,7 @@ describe('GoTrueAdminApi', () => {
         const {
           data: { user },
           error,
-        } = await clientApiAutoConfirmDisabledClient.verifyOTP({
+        } = await clientApiAutoConfirmDisabledClient.verifyOtp({
           phone: `${phone}-invalid`,
           token: otp,
           type: 'sms',

--- a/test/GoTrueClient.test.ts
+++ b/test/GoTrueClient.test.ts
@@ -52,12 +52,12 @@ describe('GoTrueClient', () => {
       expect(error).toBeNull()
       expect(data.session).not.toBeNull()
 
-      const { session: userSession, error: userError } = await authWithSession.getSession()
+      const { data: userSession, error: userError } = await authWithSession.getSession()
 
       expect(userError).toBeNull()
-      expect(userSession).not.toBeNull()
-      expect(userSession).toHaveProperty('access_token')
-      expect(userSession).toHaveProperty('user')
+      expect(userSession.session).not.toBeNull()
+      expect(userSession.session).toHaveProperty('access_token')
+      expect(userSession.session).toHaveProperty('user')
     })
 
     test('getSession() should refresh the session and return a new access token', async () => {
@@ -84,13 +84,13 @@ describe('GoTrueClient', () => {
 
       // wait 1 seconds before calling getSession()
       await new Promise((r) => setTimeout(r, 1000))
-      const { session: userSession, error: userError } = await authWithSession.getSession()
+      const { data: userSession, error: userError } = await authWithSession.getSession()
 
       expect(userError).toBeNull()
-      expect(userSession).not.toBeNull()
-      expect(userSession).toHaveProperty('access_token')
+      expect(userSession.session).not.toBeNull()
+      expect(userSession.session).toHaveProperty('access_token')
       expect(refreshAccessTokenSpy).toBeCalledTimes(1)
-      expect(data.session?.access_token).not.toEqual(userSession?.access_token)
+      expect(data.session?.access_token).not.toEqual(userSession.session?.access_token)
     })
 
     test('refresh should only happen once', async () => {
@@ -348,10 +348,10 @@ describe('GoTrueClient', () => {
     const initialSession = data.session
     expect(initialSession).not.toBeNull()
 
-    const { session, error } = await authWithSession.getSession()
+    const { data: userSession, error } = await authWithSession.getSession()
 
     expect(error).toBeNull()
-    expect(session).toMatchObject({
+    expect(userSession.session).toMatchObject({
       access_token: expect.any(String),
       refresh_token: expect.any(String),
       expires_in: expect.any(Number),
@@ -370,7 +370,7 @@ describe('GoTrueClient', () => {
         },
       },
     })
-    expect(session?.user).toMatchObject({
+    expect(userSession.session?.user).toMatchObject({
       id: expect.any(String),
       email: expect.any(String),
       phone: expect.any(String),
@@ -384,8 +384,8 @@ describe('GoTrueClient', () => {
       },
     })
 
-    expect(session?.user).not.toBeNull()
-    expect(session?.user?.email).toBe(email)
+    expect(userSession.session?.user).not.toBeNull()
+    expect(userSession.session?.user?.email).toBe(email)
   })
 
   test('signOut', async () => {
@@ -514,8 +514,8 @@ describe('User management', () => {
     expect(data.user).not.toBeNull()
 
     await authWithSession.signOut()
-    const { session, error } = await authWithSession.getSession()
-    expect(session).toBeNull()
+    const { data: userSession, error } = await authWithSession.getSession()
+    expect(userSession.session).toBeNull()
     expect(error).toBeNull()
   })
 


### PR DESCRIPTION
## What kind bugs does this PR fix?
* `signInWithPassword` was not sending a 'sign-in' event
  *  added sign-in event after a successful response
* `signInWithOAuth` ran into issues getting session from url because it was using `getUser()` which depended on an existing session to be set
  * fixed by allowing getUser to take in an optional access token jwt  
* `getSession` should also return { data, error }
*  Nit: Lowercase OTP to Otp 