### PR TITLE
fix: wait for _getSessionFromUrl()

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -124,8 +124,7 @@ export default class GoTrueClient {
       headers: settings.headers,
       fetch: settings.fetch,
     })
-    this._recoverAndRefresh()
-    this._handleVisibilityChange()
+
     this.url = settings.url
     this.headers = settings.headers
     this.fetch = resolveFetch(settings.fetch)
@@ -138,6 +137,9 @@ export default class GoTrueClient {
         }
       })
     }
+
+    this._recoverAndRefresh()
+    this._handleVisibilityChange()
   }
 
   /**
@@ -546,7 +548,7 @@ export default class GoTrueClient {
 
       const { data, error } = await this.getUser(access_token)
       if (error) throw error
-      const user: User = data.user!
+      const user: User = data.user
       const session: Session = {
         provider_token,
         access_token,
@@ -719,6 +721,8 @@ export default class GoTrueClient {
    */
   private async _recoverAndRefresh() {
     try {
+      await this.gettingSessionFromUrlPromise
+
       const currentSession = await getItemAsync(this.storage, this.storageKey)
       if (!this._doesSessionExist(currentSession)) {
         await this._removeSession()

--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -398,10 +398,12 @@ export default class GoTrueClient {
     if (this.persistSession) {
       const maybeSession = await getItemAsync(this.storage, this.storageKey)
 
-      if (this._doesSessionExist(maybeSession)) {
-        currentSession = maybeSession
-      } else {
-        await this._removeSession()
+      if (maybeSession !== null) {
+        if (this._isValidSession(maybeSession)) {
+          currentSession = maybeSession
+        } else {
+          await this._removeSession()
+        }
       }
     } else {
       currentSession = this.inMemorySession
@@ -684,7 +686,7 @@ export default class GoTrueClient {
     }
   }
 
-  private _doesSessionExist(maybeSession: unknown): maybeSession is Session {
+  private _isValidSession(maybeSession: unknown): maybeSession is Session {
     const isValidSession =
       typeof maybeSession === 'object' &&
       maybeSession !== null &&
@@ -724,8 +726,11 @@ export default class GoTrueClient {
       await this.gettingSessionFromUrlPromise
 
       const currentSession = await getItemAsync(this.storage, this.storageKey)
-      if (!this._doesSessionExist(currentSession)) {
-        await this._removeSession()
+      if (!this._isValidSession(currentSession)) {
+        if (currentSession !== null) {
+          await this._removeSession()
+        }
+
         return null
       }
 

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -69,9 +69,9 @@ export class AuthInvalidCredentialsError extends CustomAuthError {
   }
 }
 
-export class AuthMalformedCallbackUrlError extends CustomAuthError {
+export class AuthImplicitGrantRedirectError extends CustomAuthError {
   constructor(message: string) {
-    super(message, 'AuthCallbackUrlError', 500)
+    super(message, 'AuthImplicitGrantRedirectError', 500)
   }
 }
 

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -70,8 +70,19 @@ export class AuthInvalidCredentialsError extends CustomAuthError {
 }
 
 export class AuthImplicitGrantRedirectError extends CustomAuthError {
-  constructor(message: string) {
+  details: { error: string; code: string } | null = null
+  constructor(message: string, details: { error: string; code: string } | null = null) {
     super(message, 'AuthImplicitGrantRedirectError', 500)
+    this.details = details
+  }
+
+  toJSON() {
+    return {
+      name: this.name,
+      message: this.message,
+      status: this.status,
+      details: this.details,
+    }
   }
 }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -29,13 +29,21 @@ export type AuthChangeEvent =
   | 'USER_DELETED'
 
 export type GoTrueClientOptions = {
+  /* The URL of the GoTrue server. */
   url?: string
+  /* Any additional headers to send to the GoTrue server. */
   headers?: { [key: string]: string }
+  /* Optional key name used for storing tokens in local storage. */
   storageKey?: string
+  /* Set to "true" if you want to automatically detects OAuth grants in the URL and signs in the user. */
   detectSessionInUrl?: boolean
+  /* Set to "true" if you want to automatically refresh the token before expiring. */
   autoRefreshToken?: boolean
+  /* Set to "true" if you want to automatically save the user session into local storage. If set to false, session will just be saved in memory. */
   persistSession?: boolean
+  /* Provide your own local storage implementation to use instead of the browser's local storage. */
   storage?: SupportedStorage
+  /* A custom fetch implementation. */
   fetch?: Fetch
 }
 

--- a/test/GoTrueClient.test.ts
+++ b/test/GoTrueClient.test.ts
@@ -210,8 +210,11 @@ describe('GoTrueClient', () => {
     })
 
     test('_getSessionFromUrl() can only be called from a browser', async () => {
-      // @ts-expect-error 'Allow access to private _getSessionFromUrl()'
-      const { error, session } = await authWithSession._getSessionFromUrl()
+      const {
+        error,
+        data: { session },
+        // @ts-expect-error 'Allow access to private _getSessionFromUrl()'
+      } = await authWithSession._getSessionFromUrl()
 
       expect(error?.message).toEqual('No browser detected.')
       expect(session).toBeNull()


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behaviour?

`_getSessionFromUrl()` is not waited for in `getSession()`, leading to the session either coming from the URL or localStorage, depending on which one returns quicker. This is indeterministic behaviour.

## What is the new behaviour?

`getSession()` waits for `_getSessionFromUrl()`, meaning we always preference the session in the URL over localStorage.
