### PR TITLE
fix: don't throw errors in constructor

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -343,6 +343,8 @@ type PromisifyMethods<T> = {
 
 export type SupportedStorage = PromisifyMethods<Pick<Storage, 'getItem' | 'setItem' | 'removeItem'>>
 
+export type InitializeResult = { error: AuthError | null }
+
 export type CallRefreshTokenResult =
   | {
       session: Session


### PR DESCRIPTION
With this PR errors from `getUrlFromSession` are resolved in the `initialized` Promise. A consumer of the library can access the promise by calling `await client.initialize()` to access those errors.

Also it handles a callbackUrl the same way as a `verifyOtp`, `signUp`, `signInWith*` and removes an existing session from storage before continuing.

