### PR TITLE
Distinguish between various callback url errors and return errors

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -577,7 +577,14 @@ export default class GoTrueClient {
       }
 
       const error_description = getParameterByName('error_description')
-      if (error_description) throw new AuthApiError(error_description, 500)
+      if (error_description) {
+        const error_code = getParameterByName('error_code')
+        if (!error_code) throw new AuthMalformedCallbackUrlError('No error_code detected.')
+        const error = getParameterByName('error')
+        if (!error) throw new AuthMalformedCallbackUrlError('No error detected.')
+
+        throw new AuthApiError(error_description, 500)
+      }
 
       const provider_token = getParameterByName('provider_token')
       const access_token = getParameterByName('access_token')

--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -31,6 +31,7 @@ import type {
   AuthChangeEvent,
   AuthResponse,
   CallRefreshTokenResult,
+  GoTrueClientOptions,
   InitializeResult,
   OAuthResponse,
   Provider,
@@ -49,13 +50,12 @@ import type {
 
 polyfillGlobalThis() // Make "globalThis" available
 
-const DEFAULT_OPTIONS = {
+const DEFAULT_OPTIONS: Omit<Required<GoTrueClientOptions>, 'fetch' | 'storage'> = {
   url: GOTRUE_URL,
   storageKey: STORAGE_KEY,
   autoRefreshToken: true,
   persistSession: true,
   detectSessionInUrl: true,
-  multiTab: true,
   headers: DEFAULT_HEADERS,
 }
 
@@ -107,20 +107,9 @@ export default class GoTrueClient {
    * @param options.autoRefreshToken Set to "true" if you want to automatically refresh the token before expiring.
    * @param options.persistSession Set to "true" if you want to automatically save the user session into local storage. If set to false, session will just be saved in memory.
    * @param options.localStorage Provide your own local storage implementation to use instead of the browser's local storage.
-   * @param options.multiTab Set to "false" if you want to disable multi-tab/window events.
    * @param options.fetch A custom fetch implementation.
    */
-  constructor(options: {
-    url?: string
-    headers?: { [key: string]: string }
-    storageKey?: string
-    detectSessionInUrl?: boolean
-    autoRefreshToken?: boolean
-    persistSession?: boolean
-    storage?: SupportedStorage
-    multiTab?: boolean
-    fetch?: Fetch
-  }) {
+  constructor(options: GoTrueClientOptions) {
     const settings = { ...DEFAULT_OPTIONS, ...options }
     this.inMemorySession = null
     this.storageKey = settings.storageKey

--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -167,7 +167,7 @@ export default class GoTrueClient {
 
           return { error }
         } else {
-          console.warn('Malformed Callback URL detected', error);
+          console.warn('Malformed Callback URL detected', error)
         }
       }
 
@@ -573,7 +573,7 @@ export default class GoTrueClient {
   > {
     try {
       if (!this._isCallbackUrl()) {
-        return { error: new AuthMalformedCallbackUrlError('not a callback url'), session: null };
+        return { error: new AuthMalformedCallbackUrlError('not a callback url'), session: null }
       }
 
       const error_description = getParameterByName('error_description')

--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -572,6 +572,7 @@ export default class GoTrueClient {
     | { session: null; error: AuthError }
   > {
     try {
+      if (!isBrowser()) throw new AuthMalformedCallbackUrlError('No browser detected.')
       if (!this._isCallbackUrl()) {
         return { error: new AuthMalformedCallbackUrlError('not a callback url'), session: null }
       }

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -69,6 +69,12 @@ export class AuthInvalidCredentialsError extends CustomAuthError {
   }
 }
 
+export class AuthMalformedCallbackUrlError extends CustomAuthError {
+  constructor(message: string) {
+    super(message, 'AuthCallbackUrlError', 500)
+  }
+}
+
 export class AuthRetryableFetchError extends CustomAuthError {
   constructor(message: string, status: number) {
     super(message, 'AuthRetryableFetchError', status)

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,4 +1,5 @@
 import { AuthError } from './errors'
+import { Fetch } from './fetch';
 
 /** One of the providers supported by GoTrue. */
 export type Provider =
@@ -26,6 +27,17 @@ export type AuthChangeEvent =
   | 'TOKEN_REFRESHED'
   | 'USER_UPDATED'
   | 'USER_DELETED'
+
+export type GoTrueClientOptions = {
+  url?: string
+  headers?: { [key: string]: string }
+  storageKey?: string
+  detectSessionInUrl?: boolean
+  autoRefreshToken?: boolean
+  persistSession?: boolean
+  storage?: SupportedStorage
+  fetch?: Fetch
+}
 
 export type AuthResponse =
   | {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,5 +1,5 @@
 import { AuthError } from './errors'
-import { Fetch } from './fetch';
+import { Fetch } from './fetch'
 
 /** One of the providers supported by GoTrue. */
 export type Provider =

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -343,6 +343,8 @@ type PromisifyMethods<T> = {
 
 export type SupportedStorage = PromisifyMethods<Pick<Storage, 'getItem' | 'setItem' | 'removeItem'>>
 
+export type InitializeResult = { error: AuthError | null }
+
 export type CallRefreshTokenResult =
   | {
       session: Session


### PR DESCRIPTION
This builds up on #393 and improves it by distinguishing between errors originating from mal formed callback urls and real errors (eg. `error_decription` in url, error during `getUser()`).
When a malformed callback url is detected the error is ignored, and the initialization continues with `_recoverAndRefresh`

Also i removed `multiTab` from options, as this setting is not used anymore.  