### PR TITLE
fix: move isBrowser localStorage check + other small fixes

### DIFF
--- a/src/GoTrueAdminApi.ts
+++ b/src/GoTrueAdminApi.ts
@@ -50,7 +50,7 @@ export default class GoTrueAdminApi {
   /**
    * Sends an invite link to an email address.
    * @param email The email address of the user.
-   * @param options.redirectTo A URL or mobile address to send the user to after they are confirmed.
+   * @param options.redirectTo A URL or mobile deeplink to send the user to after they are confirmed.
    * @param options.data Optional user metadata
    */
   async inviteUserByEmail(

--- a/src/GoTrueAdminApi.ts
+++ b/src/GoTrueAdminApi.ts
@@ -91,17 +91,18 @@ export default class GoTrueAdminApi {
    */
   async generateLink(params: GenerateLinkParams): Promise<GenerateLinkResponse> {
     try {
+      const { options, ...rest } = params
+      const body: any = { ...rest, ...options }
+      if ('newEmail' in rest) {
+        // replace newEmail with new_email in request body
+        body.new_email = rest?.newEmail
+        delete body['newEmail']
+      }
       return await _request(this.fetch, 'POST', `${this.url}/admin/generate_link`, {
-        body: {
-          type: params.type,
-          email: params.email,
-          new_email: params.options?.new_email,
-          password: params.options?.password,
-          data: params.options?.data,
-          redirect_to: params.options?.redirectTo,
-        },
+        body: body,
         headers: this.headers,
         xform: _generateLinkResponse,
+        redirectTo: options?.redirectTo,
       })
     } catch (error) {
       if (isAuthError(error)) {

--- a/src/GoTrueAdminApi.ts
+++ b/src/GoTrueAdminApi.ts
@@ -1,6 +1,12 @@
-import { Fetch, _request, _userResponse } from './lib/fetch'
+import { Fetch, _generateLinkResponse, _request, _userResponse } from './lib/fetch'
 import { resolveFetch } from './lib/helpers'
-import { AdminUserAttributes, GenerateLinkType, Session, User, UserResponse } from './lib/types'
+import {
+  AdminUserAttributes,
+  GenerateLinkParams,
+  GenerateLinkResponse,
+  User,
+  UserResponse,
+} from './lib/types'
 import { AuthError, isAuthError } from './lib/errors'
 
 export default class GoTrueAdminApi {
@@ -83,39 +89,29 @@ export default class GoTrueAdminApi {
    * @param options.data Optional user metadata. For signup only.
    * @param options.redirectTo The redirect url which should be appended to the generated link
    */
-  async generateLink(
-    type: GenerateLinkType,
-    email: string,
-    options: {
-      password?: string
-      data?: object
-      redirectTo?: string
-    } = {}
-  ): Promise<
-    | {
-        data: User
-        error: null
-      }
-    | {
-        data: Session
-        error: null
-      }
-    | { data: null; error: AuthError }
-  > {
+  async generateLink(params: GenerateLinkParams): Promise<GenerateLinkResponse> {
     try {
       return await _request(this.fetch, 'POST', `${this.url}/admin/generate_link`, {
         body: {
-          type,
-          email,
-          password: options.password,
-          data: options.data,
-          redirect_to: options.redirectTo,
+          type: params.type,
+          email: params.email,
+          new_email: params.options?.new_email,
+          password: params.options?.password,
+          data: params.options?.data,
+          redirect_to: params.options?.redirectTo,
         },
         headers: this.headers,
+        xform: _generateLinkResponse,
       })
     } catch (error) {
       if (isAuthError(error)) {
-        return { data: null, error }
+        return {
+          data: {
+            properties: null,
+            user: null,
+          },
+          error,
+        }
       }
       throw error
     }

--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -26,6 +26,7 @@ import {
   setItemAsync,
   uuid,
 } from './lib/helpers'
+import localStorageAdapter from './lib/local-storage'
 import { polyfillGlobalThis } from './lib/polyfills'
 import type {
   AuthChangeEvent,
@@ -106,7 +107,7 @@ export default class GoTrueClient {
     this.storageKey = settings.storageKey
     this.autoRefreshToken = settings.autoRefreshToken
     this.persistSession = settings.persistSession
-    this.storage = settings.storage || globalThis.localStorage
+    this.storage = settings.storage || localStorageAdapter
     this.admin = new GoTrueAdminApi({
       url: settings.url,
       headers: settings.headers,
@@ -937,9 +938,10 @@ export default class GoTrueClient {
     }
 
     try {
-      window?.addEventListener('visibilitychange', () => {
+      window?.addEventListener('visibilitychange', async () => {
         if (document.visibilityState === 'visible') {
-          this._recoverAndRefresh()
+          await this.initializePromise
+          await this._recoverAndRefresh()
         }
       })
     } catch (error) {

--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -356,16 +356,8 @@ export default class GoTrueClient {
 
   /**
    * Log in a user given a User supplied OTP received via mobile.
-   * @param options.redirectTo A URL to send the user to after they are confirmed.
-   * @param options.captchaToken Verification token received when the user completes the captcha on the site.
    */
-  async verifyOtp(
-    params: VerifyOtpParams,
-    options: {
-      redirectTo?: string
-      captchaToken?: string
-    } = {}
-  ): Promise<AuthResponse> {
+  async verifyOtp(params: VerifyOtpParams): Promise<AuthResponse> {
     try {
       await this._removeSession()
 
@@ -373,9 +365,9 @@ export default class GoTrueClient {
         headers: this.headers,
         body: {
           ...params,
-          gotrue_meta_security: { captchaToken: options?.captchaToken },
+          gotrue_meta_security: { captchaToken: params.options?.captchaToken },
         },
-        redirectTo: options.redirectTo,
+        redirectTo: params.options?.redirectTo,
         xform: _sessionResponse,
       })
 

--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -314,6 +314,9 @@ export default class GoTrueClient {
 
   /**
    * Passwordless method for logging in an existing user.
+   * A one-time password (OTP) can either be in the form of an email link or a numerical code.
+   * You can decide whether to send an email link or code or both in your email template.
+   * If you're using passwordless phone sign-ins, your OTP will always be in the form of a code.
    */
   async signInWithOtp(credentials: SignInWithPasswordlessCredentials): Promise<AuthResponse> {
     try {

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -1,5 +1,11 @@
 import { expiresAt, resolveResponse } from './helpers'
-import { AuthResponse, User, UserResponse } from './types'
+import {
+  AuthResponse,
+  GenerateLinkProperties,
+  GenerateLinkResponse,
+  User,
+  UserResponse,
+} from './types'
 import { AuthApiError, AuthRetryableFetchError, AuthUnknownError } from './errors'
 
 export type Fetch = typeof fetch
@@ -129,6 +135,27 @@ export function _sessionResponse(data: any): AuthResponse {
 export function _userResponse(data: any): UserResponse {
   const user: User = data.user ?? (data as User)
   return { data: { user }, error: null }
+}
+
+export function _generateLinkResponse(data: any): GenerateLinkResponse {
+  const { action_link, email_otp, hashed_token, redirect_to, verification_type, ...rest } = data
+
+  const properties: GenerateLinkProperties = {
+    action_link,
+    email_otp,
+    hashed_token,
+    redirect_to,
+    verification_type,
+  }
+
+  const user: User = { ...rest }
+  return {
+    data: {
+      properties,
+      user,
+    },
+    error: null,
+  }
 }
 
 /**

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -48,18 +48,22 @@ export const resolveResponse = async () => {
   return Response
 }
 
-// LocalStorage helpers
+// Storage helpers
 export const setItemAsync = async (
   storage: SupportedStorage,
   key: string,
   data: any
 ): Promise<void> => {
-  isBrowser() && (await storage?.setItem(key, JSON.stringify(data)))
+  await storage.setItem(key, JSON.stringify(data))
 }
 
 export const getItemAsync = async (storage: SupportedStorage, key: string): Promise<unknown> => {
-  const value = isBrowser() && (await storage?.getItem(key))
-  if (!value) return null
+  const value = await storage.getItem(key)
+
+  if (!value) {
+    return null
+  }
+
   try {
     return JSON.parse(value)
   } catch {
@@ -68,7 +72,7 @@ export const getItemAsync = async (storage: SupportedStorage, key: string): Prom
 }
 
 export const removeItemAsync = async (storage: SupportedStorage, key: string): Promise<void> => {
-  isBrowser() && (await storage?.removeItem(key))
+  await storage.removeItem(key)
 }
 
 /**

--- a/src/lib/local-storage.ts
+++ b/src/lib/local-storage.ts
@@ -1,0 +1,28 @@
+import { isBrowser } from './helpers'
+import { SupportedStorage } from './types'
+
+const localStorageAdapter: SupportedStorage = {
+  getItem: (key) => {
+    if (!isBrowser()) {
+      return null
+    }
+
+    return globalThis.localStorage.getItem(key)
+  },
+  setItem: (key, value) => {
+    if (!isBrowser()) {
+      return
+    }
+
+    globalThis.localStorage.setItem(key, value)
+  },
+  removeItem: (key) => {
+    if (!isBrowser()) {
+      return
+    }
+
+    globalThis.localStorage.removeItem(key)
+  },
+}
+
+export default localStorageAdapter

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -355,27 +355,52 @@ export interface VerifyEmailOtpParams {
 export type MobileOtpType = 'sms' | 'phone_change'
 export type EmailOtpType = 'signup' | 'invite' | 'magiclink' | 'recovery' | 'email_change'
 
-export type GenerateLinkParams = {
-  type: GenerateLinkType
+export type GenerateSignupLinkParams = {
+  type: 'signup'
+  email: string
+  password: string
+  options?: Pick<GenerateLinkOptions, 'data' | 'redirectTo'>
+}
+
+export type GenerateInviteOrMagiclinkParams = {
+  type: 'invite' | 'magiclink'
   /** The user's email */
   email: string
-  options?: {
-    /**
-     * The user's new email. Only required if type is 'email_change_current' or 'email_change_new'.
-     */
-    new_email?: string
-    /**
-     * The user's password. Only required if type is 'signup'.
-     */
-    password?: string
-    /**
-     * The user's metadata. Only valid if type is 'signup', 'magiclink' or 'invite'.
-     */
-    data?: object
-    /** The URL which will be appended to the email link generated. */
-    redirectTo?: string
-  }
+  options?: Pick<GenerateLinkOptions, 'data' | 'redirectTo'>
 }
+
+export type GenerateRecoveryLinkParams = {
+  type: 'recovery'
+  /** The user's email */
+  email: string
+  options?: Pick<GenerateLinkOptions, 'redirectTo'>
+}
+
+export type GenerateEmailChangeLinkParams = {
+  type: 'email_change_current' | 'email_change_new'
+  /** The user's email */
+  email: string
+  /**
+   * The user's new email. Only required if type is 'email_change_current' or 'email_change_new'.
+   */
+  newEmail: string
+  options?: Pick<GenerateLinkOptions, 'redirectTo'>
+}
+
+export interface GenerateLinkOptions {
+  /**
+   * The user's metadata.
+   */
+  data?: object
+  /** The URL which will be appended to the email link generated. */
+  redirectTo?: string
+}
+
+export type GenerateLinkParams =
+  | GenerateSignupLinkParams
+  | GenerateInviteOrMagiclinkParams
+  | GenerateRecoveryLinkParams
+  | GenerateEmailChangeLinkParams
 
 export type GenerateLinkResponse =
   | {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -313,7 +313,7 @@ export type SignInWithOAuthCredentials = {
   /** One of the providers supported by GoTrue. */
   provider: Provider
   options?: {
-    /** A URL to send the user to after they are confirmed (OAuth logins only). */
+    /** A URL to send the user to after they are confirmed. */
     redirectTo?: string
     /** A space-separated list of scopes granted to the OAuth application. */
     scopes?: string
@@ -330,6 +330,12 @@ export interface VerifyMobileOtpParams {
   token: string
   /** The user's verification type. */
   type: MobileOtpType
+  options?: {
+    /** A URL to send the user to after they are confirmed. */
+    redirectTo?: string
+    /** Verification token received when the user completes the captcha on the site. */
+    captchaToken?: string
+  }
 }
 export interface VerifyEmailOtpParams {
   /** The user's email address. */
@@ -338,6 +344,12 @@ export interface VerifyEmailOtpParams {
   token: string
   /** The user's verification type. */
   type: EmailOtpType
+  options?: {
+    /** A URL to send the user to after they are confirmed. */
+    redirectTo?: string
+    /** Verification token received when the user completes the captcha on the site. */
+    captchaToken?: string
+  }
 }
 
 export type MobileOtpType = 'sms' | 'phone_change'

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -355,7 +355,66 @@ export interface VerifyEmailOtpParams {
 export type MobileOtpType = 'sms' | 'phone_change'
 export type EmailOtpType = 'signup' | 'invite' | 'magiclink' | 'recovery' | 'email_change'
 
-/** The link type */
+export type GenerateLinkParams = {
+  type: GenerateLinkType
+  /** The user's email */
+  email: string
+  options?: {
+    /**
+     * The user's new email. Only required if type is 'email_change_current' or 'email_change_new'.
+     */
+    new_email?: string
+    /**
+     * The user's password. Only required if type is 'signup'.
+     */
+    password?: string
+    /**
+     * The user's metadata. Only valid if type is 'signup', 'magiclink' or 'invite'.
+     */
+    data?: object
+    /** The URL which will be appended to the email link generated. */
+    redirectTo?: string
+  }
+}
+
+export type GenerateLinkResponse =
+  | {
+      data: {
+        properties: GenerateLinkProperties
+        user: User
+      }
+      error: null
+    }
+  | {
+      data: {
+        properties: null
+        user: null
+      }
+      error: AuthError
+    }
+
+/** The properties related to the email link generated  */
+export type GenerateLinkProperties = {
+  /**
+   * The email link to send to the user.
+   * The action_link follows the following format: auth/v1/verify?type={verification_type}&token={hashed_token}&redirect_to={redirect_to}
+   * */
+  action_link: string
+  /**
+   * The raw email OTP.
+   * You should send this in the email if you want your users to verify using an OTP instead of the action link.
+   * */
+  email_otp: string
+  /**
+   * The hashed token appended to the action link.
+   * */
+  hashed_token: string
+  /** The URL appended to the action link. */
+  redirect_to: string
+  /** The verification type that the email link is associated to. */
+  verification_type: GenerateLinkType
+}
+
 export type GenerateLinkType =
   | 'signup'
   | 'invite'

--- a/test/GoTrueApi.test.ts
+++ b/test/GoTrueApi.test.ts
@@ -13,7 +13,7 @@ import {
   mockVerificationOTP,
 } from './lib/utils'
 
-import type { User } from '../src/lib/types'
+import type { GenerateLinkProperties, User } from '../src/lib/types'
 
 describe('GoTrueAdminApi', () => {
   describe('User creation', () => {
@@ -269,22 +269,38 @@ describe('GoTrueAdminApi', () => {
       const redirectTo = 'http://localhost:9999/welcome'
       const userMetadata = { status: 'alpha' }
 
-      const { error, data } = await serviceRoleApiClient.generateLink('signup', email, {
-        password: password,
-        data: userMetadata,
-        redirectTo,
+      const { error, data } = await serviceRoleApiClient.generateLink({
+        type: 'signup',
+        email,
+        options: {
+          password: password,
+          data: userMetadata,
+          redirectTo,
+        },
       })
 
-      const user = data as User
+      const properties = data.properties as GenerateLinkProperties
+      const user = data.user as User
 
       expect(error).toBeNull()
+      /** Check that the user object returned has the update metadata and an email */
       expect(user).not.toBeNull()
-      expect(user).toHaveProperty('action_link')
-      expect(user?.['action_link']).toMatch(/\?token/)
-      expect(user?.['action_link']).toMatch(/type=signup/)
-      expect(user?.['action_link']).toMatch(new RegExp(`redirect_to=${redirectTo}`))
+      expect(user).toHaveProperty('email')
       expect(user).toHaveProperty('user_metadata')
       expect(user?.['user_metadata']).toEqual(userMetadata)
+
+      /** Check that properties returned contains the generateLink properties */
+      expect(properties).not.toBeNull()
+      expect(properties).toHaveProperty('action_link')
+      expect(properties).toHaveProperty('email_otp')
+      expect(properties).toHaveProperty('hashed_token')
+      expect(properties).toHaveProperty('redirect_to')
+      expect(properties).toHaveProperty('verification_type')
+
+      /** Check if the action link returned is correctly formatted */
+      expect(properties?.['action_link']).toMatch(/\?token/)
+      expect(properties?.['action_link']).toMatch(/type=signup/)
+      expect(properties?.['action_link']).toMatch(new RegExp(`redirect_to=${redirectTo}`))
     })
 
     test('inviteUserByEmail() creates a new user with an invited_at timestamp', async () => {
@@ -362,6 +378,57 @@ describe('GoTrueAdminApi', () => {
         expect(user).toBeNull()
         expect(error?.message).toEqual('Invalid phone number format')
       })
+    })
+  })
+
+  describe('User updates email', () => {
+    test('generateLink supports updating emails with generate email change links ', async () => {
+      const { email, password } = mockUserCredentials()
+      const {
+        data: { user: createdUser },
+        error: createError,
+      } = await createNewUserWithEmail({
+        email,
+        password,
+      })
+      expect(createError).toBeNull()
+      expect(createdUser).not.toBeNull()
+
+      const { email: newEmail } = mockUserCredentials()
+      const redirectTo = 'http://localhost:9999/welcome'
+
+      const { data, error } = await serviceRoleApiClient.generateLink({
+        type: 'email_change_current',
+        email,
+        options: {
+          new_email: newEmail,
+          redirectTo,
+        },
+      })
+
+      const properties = data.properties as GenerateLinkProperties
+      const user = data.user as User
+
+      expect(error).toBeNull()
+      /** Check that the user object returned has the update metadata and an email */
+      expect(user).not.toBeNull()
+      expect(user).toHaveProperty('email')
+      expect(user).toHaveProperty('new_email')
+      expect(user).toHaveProperty('user_metadata')
+      expect(user?.new_email).toEqual(newEmail)
+
+      /** Check that properties returned contains the generateLink properties */
+      expect(properties).not.toBeNull()
+      expect(properties).toHaveProperty('action_link')
+      expect(properties).toHaveProperty('email_otp')
+      expect(properties).toHaveProperty('hashed_token')
+      expect(properties).toHaveProperty('redirect_to')
+      expect(properties).toHaveProperty('verification_type')
+
+      /** Check if the action link returned is correctly formatted */
+      expect(properties?.['action_link']).toMatch(/\?token/)
+      expect(properties?.['action_link']).toMatch(/type=email_change/)
+      expect(properties?.['action_link']).toMatch(new RegExp(`redirect_to=${redirectTo}`))
     })
   })
 })

--- a/test/GoTrueClient.test.ts
+++ b/test/GoTrueClient.test.ts
@@ -596,9 +596,9 @@ describe('The auth client can signin with third-party oAuth providers', () => {
   })
 
   describe('Developers can subscribe and unsubscribe', () => {
-    const { subscription } = authSubscriptionClient.onAuthStateChange(() =>
-      console.log('onAuthStateChange was called')
-    )
+    const {
+      data: { subscription },
+    } = authSubscriptionClient.onAuthStateChange(() => console.log('onAuthStateChange was called'))
 
     test('Subscribe a listener', async () => {
       // @ts-expect-error 'Allow access to protected stateChangeEmitters'


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behaviour?

If you provide a custom storage adapter server side, it acts as a no-op as `gotrue-js` only calls storage implementations in the browser.

## What is the new behaviour?

Storage is now always called if `persistSession` is `true`.

## Additional context

Cookie storage is now a viable option to use server side.
