### PR TITLE
Added options with redirectTo for user update

### DIFF
--- a/src/GoTrueApi.ts
+++ b/src/GoTrueApi.ts
@@ -843,10 +843,17 @@ export default class GoTrueApi {
    */
   async updateUser(
     jwt: string,
-    attributes: UserAttributes
+    attributes: UserAttributes,
+    options?: {
+      redirectTo?: string
+    }
   ): Promise<{ user: User | null; data: User | null; error: ApiError | null }> {
     try {
-      const data: any = await put(this.fetch, `${this.url}/user`, attributes, {
+      const urlParams: string[] = []
+      if (options?.redirectTo) {
+        urlParams.push(`redirect_to=${encodeURIComponent(options.redirectTo)}`)
+      }
+      const data: any = await put(this.fetch, `${this.url}/user?${urlParams.join('&')}`, attributes, {
         headers: this._createRequestHeaders(jwt),
       })
       return { user: data, data, error: null }

--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -358,14 +358,18 @@ export default class GoTrueClient {
    * Updates user data, if there is a logged in user.
    */
   async update(
-    attributes: UserAttributes
+    attributes: UserAttributes,
+    options?: {
+      redirectTo?: string
+    }
   ): Promise<{ data: User | null; user: User | null; error: ApiError | null }> {
     try {
       if (!this.currentSession?.access_token) throw new Error('Not logged in.')
 
       const { user, error } = await this.api.updateUser(
         this.currentSession.access_token,
-        attributes
+        attributes,
+        options
       )
       if (error) throw error
       if (!user) throw Error('Invalid user data.')


### PR DESCRIPTION
## What kind of change does this PR introduce?

Accept `options` object with `redirectTo` and send it as a query parameter to the endpoint.

## What is the current behavior?

While GoTrue accepts a query parameter for url redirect, there is no way to set it inside gotrue-js.
It's probably not the best solution, it may be better to create a different method for user email change, as mentioned in the issue.

## What is the new behavior?

Accept `options` object with `redirectTo` and send it as a query parameter to the endpoint.

## Additional context

Look at [this issue](https://github.com/supabase/gotrue/issues/962)
