### PR TITLE
chore: Add CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @supabase/auth


### PR DESCRIPTION
Adds the Supabase Auth team as code owner.