### PR TITLE
fix: handle custom fetch error responses

### DIFF
--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -1,4 +1,4 @@
-import { expiresAt, resolveResponse } from './helpers'
+import { expiresAt, looksLikeFetchResponse } from './helpers'
 import {
   AuthResponse,
   GenerateLinkProperties,
@@ -27,9 +27,7 @@ const _getErrorMessage = (err: any): string =>
   err.msg || err.message || err.error_description || err.error || JSON.stringify(err)
 
 const handleError = async (error: unknown, reject: (reason?: any) => void) => {
-  const Res = await resolveResponse()
-
-  if (!(error instanceof Res)) {
+  if (!(looksLikeFetchResponse(error))) {
     reject(new AuthRetryableFetchError(_getErrorMessage(error), 0))
   } else if (error.status >= 500 && error.status <= 599) {
     // status in 500...599 range - server had an error, request might be retryed.

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -27,7 +27,7 @@ const _getErrorMessage = (err: any): string =>
   err.msg || err.message || err.error_description || err.error || JSON.stringify(err)
 
 const handleError = async (error: unknown, reject: (reason?: any) => void) => {
-  if (!(looksLikeFetchResponse(error))) {
+  if (!looksLikeFetchResponse(error)) {
     reject(new AuthRetryableFetchError(_getErrorMessage(error), 0))
   } else if (error.status >= 500 && error.status <= 599) {
     // status in 500...599 range - server had an error, request might be retryed.

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -40,6 +40,17 @@ export const resolveFetch = (customFetch?: Fetch): Fetch => {
   return (...args) => _fetch(...args)
 }
 
+export const looksLikeFetchResponse = (maybeResponse: unknown): maybeResponse is Response => {
+  return (
+    typeof maybeResponse === 'object'
+    && maybeResponse !== null
+    && 'status' in maybeResponse
+    && 'ok' in maybeResponse
+    && 'json' in maybeResponse
+    && typeof (maybeResponse as any).json === 'function'
+  )
+}
+
 export const resolveResponse = async () => {
   if (typeof Response === 'undefined') {
     return (await import('cross-fetch')).Response

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -42,12 +42,12 @@ export const resolveFetch = (customFetch?: Fetch): Fetch => {
 
 export const looksLikeFetchResponse = (maybeResponse: unknown): maybeResponse is Response => {
   return (
-    typeof maybeResponse === 'object'
-    && maybeResponse !== null
-    && 'status' in maybeResponse
-    && 'ok' in maybeResponse
-    && 'json' in maybeResponse
-    && typeof (maybeResponse as any).json === 'function'
+    typeof maybeResponse === 'object' &&
+    maybeResponse !== null &&
+    'status' in maybeResponse &&
+    'ok' in maybeResponse &&
+    'json' in maybeResponse &&
+    typeof (maybeResponse as any).json === 'function'
   )
 }
 

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -51,14 +51,6 @@ export const looksLikeFetchResponse = (maybeResponse: unknown): maybeResponse is
   )
 }
 
-export const resolveResponse = async () => {
-  if (typeof Response === 'undefined') {
-    return (await import('cross-fetch')).Response
-  }
-
-  return Response
-}
-
 // Storage helpers
 export const setItemAsync = async (
   storage: SupportedStorage,

--- a/test/fetch.test.ts
+++ b/test/fetch.test.ts
@@ -16,7 +16,7 @@ describe('fetch', () => {
         .get('/')
         .mockImplementationOnce((ctx) => {
           ctx.status = 400
-          ctx.body = {'message': 'invalid params'}
+          ctx.body = { message: 'invalid params' }
         })
         .mockImplementation((ctx) => {
           ctx.status = 200
@@ -110,9 +110,9 @@ describe('fetch', () => {
           status: 400,
           ok: false,
           json: async () => {
-            return {'message': 'invalid params'}
-          }
-        };
+            return { message: 'invalid params' }
+          },
+        }
       }) as unknown as typeof fetch
 
       const url = server.getURL().toString()

--- a/test/fetch.test.ts
+++ b/test/fetch.test.ts
@@ -103,5 +103,21 @@ describe('fetch', () => {
 
       await server.start()
     })
+
+    test('should work with custom fetch implementation', async () => {
+      const customFetch = (async () => {
+        return {
+          status: 400,
+          ok: false,
+          json: async () => {
+            return {'message': 'invalid params'}
+          }
+        };
+      }) as unknown as typeof fetch
+
+      const url = server.getURL().toString()
+
+      await expect(_request(customFetch, 'GET', url)).rejects.toBeInstanceOf(AuthApiError)
+    })
   })
 })

--- a/test/fetch.test.ts
+++ b/test/fetch.test.ts
@@ -1,6 +1,6 @@
 import { MockServer } from 'jest-mock-server'
 import fetch from 'cross-fetch'
-import { AuthUnknownError, AuthRetryableFetchError } from '../src/lib/errors'
+import { AuthUnknownError, AuthApiError, AuthRetryableFetchError } from '../src/lib/errors'
 import { _request } from '../src/lib/fetch'
 
 describe('fetch', () => {
@@ -16,7 +16,7 @@ describe('fetch', () => {
         .get('/')
         .mockImplementationOnce((ctx) => {
           ctx.status = 400
-          ctx.body = 'Bad Request'
+          ctx.body = {'message': 'invalid params'}
         })
         .mockImplementation((ctx) => {
           ctx.status = 200
@@ -24,7 +24,7 @@ describe('fetch', () => {
 
       const url = server.getURL().toString()
 
-      await expect(_request(fetch, 'GET', url)).rejects.toBeInstanceOf(AuthUnknownError)
+      await expect(_request(fetch, 'GET', url)).rejects.toBeInstanceOf(AuthApiError)
 
       expect(route).toHaveBeenCalledTimes(1)
     })


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

If a custom fetch implementation does not return a Response that is a instance of native fetch Response or a cross-fetch Response the `instanceof` check in the error handler fails.

## What is the new behavior?

The fetch responses are checked with a utility method

## Additional context

See [discussion in discord](https://discord.com/channels/839993398554656828/1011280048495542402)
