### PR TITLE
fix: send `application/json` in Content-Type header

### DIFF
--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -36,7 +36,7 @@ const _getRequestParams = (method: RequestMethodType, options?: FetchOptions, bo
     return params
   }
 
-  params.headers = { 'Content-Type': 'text/plain;charset=UTF-8', ...options?.headers }
+  params.headers = { 'Content-Type': 'application/json;charset=UTF-8', ...options?.headers }
   params.body = JSON.stringify(body)
 
   return params


### PR DESCRIPTION
Resolves issue #205 

supabase/gotrue:v2.16.3 does not permit requests with content-type `text/plain` and is therefore replaced with `application/json`