### PR TITLE
fix: fix storage for browsers without local storage

### DIFF
--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -15,6 +15,9 @@ export function uuid() {
 
 export const isBrowser = () => typeof window !== 'undefined'
 
+export const supportsLocalStorage = () =>
+  isBrowser() && typeof globalThis.localStorage !== 'undefined'
+
 export function getParameterByName(name: string, url?: string) {
   if (!url) url = window?.location?.href || ''
   // eslint-disable-next-line no-useless-escape

--- a/src/lib/local-storage.ts
+++ b/src/lib/local-storage.ts
@@ -1,23 +1,23 @@
-import { isBrowser } from './helpers'
+import { supportsLocalStorage } from './helpers'
 import { SupportedStorage } from './types'
 
 const localStorageAdapter: SupportedStorage = {
   getItem: (key) => {
-    if (!isBrowser()) {
+    if (!supportsLocalStorage()) {
       return null
     }
 
     return globalThis.localStorage.getItem(key)
   },
   setItem: (key, value) => {
-    if (!isBrowser()) {
+    if (!supportsLocalStorage()) {
       return
     }
 
     globalThis.localStorage.setItem(key, value)
   },
   removeItem: (key) => {
-    if (!isBrowser()) {
+    if (!supportsLocalStorage()) {
       return
     }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

There are some edge cases where a browser does have `window` defined but not `globalThis.localStorage`. Currently gotrue-js will throw in these environments.
See #433 

## What is the new behavior?
Before accessing `globalThis.localStorage` it is verified that `globalThis.localStorage` is not undefined.

## Additional context

Wasn't really able to test this change so far, therefore opening as draft.
