### PR TITLE
Support refresh token syncing for multiple tabs

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -860,6 +860,7 @@ export default class GoTrueClient {
       }
 
       if (!syncedSession) {
+        // Cache refresh token status for other tabs
         await setItemAsync(this.storage, this.refreshTokenSyncStorageKey, {
           refresh_token: refreshToken,
           status: 'TOKEN_REFRESHING',
@@ -885,6 +886,8 @@ export default class GoTrueClient {
 
       return result
     } catch (error) {
+      await removeItemAsync(this.storage, this.refreshTokenSyncStorageKey)
+
       if (isAuthError(error)) {
         const result = { session: null, error }
 
@@ -963,6 +966,7 @@ export default class GoTrueClient {
   private async _removeSession() {
     if (this.persistSession) {
       await removeItemAsync(this.storage, this.storageKey)
+      await removeItemAsync(this.storage, this.refreshTokenSyncStorageKey)
     } else {
       this.inMemorySession = null
     }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -465,6 +465,11 @@ type PromisifyMethods<T> = {
     : T[K]
 }
 
+export interface SyncTokenRefreshStorage {
+  refresh_token: string
+  status: 'TOKEN_REFRESHING' | 'TOKEN_REFRESHED'
+}
+
 export type SupportedStorage = PromisifyMethods<Pick<Storage, 'getItem' | 'setItem' | 'removeItem'>>
 
 export type InitializeResult = { error: AuthError | null }


### PR DESCRIPTION
## What kind of change does this PR introduce?

This change introduces a mechanism to sync refresh tokens at the client level, rather than depending on the backend.
The current behavior of supabase-js v2 unfortunately continues to log out users. This was reproducible with at least three tabs. More information here: https://github.com/supabase/gotrue-js/issues/454 and https://github.com/supabase/gotrue-js/issues/442

### Implementation Details

The sync logic uses `this.storage` to cache the status of the refresh token request. The only properties stored are `refresh_token` and `status`. Check `SyncTokenRefreshStorage`.


- `TOKEN_REFRESHING` is set on status before the API request is made.
- `TOKEN_REFRESHED` is set on status after the API request resolved.

For any tab that attemps to refresh the token.


- If status in storage is `TOKEN_REFRESHING`. It waits until token has refreshed, then pulls latest session from storage
- If status in storage is `TOKEN_REFRESHED`. it pulls latest session from storage
- In both cases, the latestSession is validated, to check if it’s not about to expire.


## What is the current behavior?

The user is logged out with at least three tabs: https://github.com/supabase/gotrue-js/issues/454
Notice a burst of network requests to the API. Eventually, this causes a 400 error, logging out the user. Check timestamps.
* This screenshot represents 8 instances, lasting only 9 minutes before timing out.

<img width="904" alt="cleanshot_09_19_at_14_54@2x" src="https://user-images.githubusercontent.com/6182543/191104627-fb025d6a-1095-4bef-a9a1-ff58e0b70ed7.png">


## What is the new behavior?
The tabs depend on only one request to succeed. The remainder tabs wait until the refresh token is retrieved from the API to resolve. Providing a clean POST request of one to the API. Check timestamps.

<img width="1504" alt="cleanshot_09_19_at_15_12@2x" src="https://user-images.githubusercontent.com/6182543/191105089-78c77349-c8dd-4e71-bd25-7cd333e191e8.png">


## Additional context
* Multi-requests can still happen if the timer for tabs have an identical cycle. This is where we would fallback on the backend with the reuse interval logic
* Another idea I had was to idle the supabase instance if the user put the tab in the background. I was concerned this approach would introduce unwanted behaviors for devs that use supabase requests while in the background. Let me know if this is worth pursuing. Just throwing that idea out there.
* For debugging I found `mitmproxy` extremely helpful to view the requests
   * Configuration details for mac: https://blogs.aaddevsup.xyz/2018/04/tracing-all-network-machine-traffic-using-mitmproxy-for-mac-osx/
   * Run `mitmproxy --mode socks5 --showhost --view-filter="~u supabase.co ~m POST"`
* Here are the auth configuration changes I tested. 30 second JWT expiry and 10 second reuse interval
* Definitely a preliminary change. I'd love to get feedback and potential gotchas. So far with testing, no 400 errors. I plan on testing this further with a production app I'm building. As this was causing me a bit of headache. The production app is currently running supabase-js v1, but I still found issues in v2.


Edit: Tue Sept 20 - Included Implementation Details