### PR TITLE
feat: add provider refresh token to session

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -435,6 +435,7 @@ export default class GoTrueClient {
       if (error_description) throw new Error(error_description)
 
       const provider_token = getParameterByName('provider_token')
+      const provider_refresh_token = getParameterByName('provider_refresh_token')
       const access_token = getParameterByName('access_token')
       if (!access_token) throw new Error('No access_token detected.')
       const expires_in = getParameterByName('expires_in')
@@ -452,6 +453,7 @@ export default class GoTrueClient {
 
       const session: Session = {
         provider_token,
+        provider_refresh_token,
         access_token,
         expires_in: parseInt(expires_in),
         expires_at,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -31,6 +31,7 @@ export interface ApiError {
 
 export interface Session {
   provider_token?: string | null
+  provider_refresh_token?: string | null
   access_token: string
   /**
    * The number of seconds until the token expires (since it was issued). Returned when a login is confirmed.


### PR DESCRIPTION
## What kind of change does this PR introduce?

- adds `provider_refresh_token` to Session object.
- closes  #[131](https://github.com/supabase/gotrue-js/issues/131)