### PR TITLE
fix: log error in `getUserByCookie`

### DIFF
--- a/src/GoTrueApi.ts
+++ b/src/GoTrueApi.ts
@@ -736,6 +736,7 @@ export default class GoTrueApi {
 
       const { user, error: getUserError } = await this.getUser(access_token)
       if (getUserError) {
+        console.error('getUserByCookie failed with error', getUserError)
         if (!refresh_token) throw new Error('No refresh_token cookie found!')
         if (!res)
           throw new Error('You need to pass the res object to automatically refresh the session!')


### PR DESCRIPTION
If an error occurs in `GoTrueApi#getUserByCookie` when calling `getUser`, the actual root cause will be masked, which may confuse developers as to what may be going on.

See: #238.