### PR TITLE
refactor: use named metadata types on User (next)

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -107,15 +107,19 @@ export interface UserIdentity {
   updated_at?: string
 }
 
+export interface UserAppMetadata {
+  provider?: string
+  [key: string]: any
+}
+
+export interface UserMetadata {
+  [key: string]: any
+}
+
 export interface User {
   id: string
-  app_metadata: {
-    provider?: string
-    [key: string]: any
-  }
-  user_metadata: {
-    [key: string]: any
-  }
+  app_metadata: UserAppMetadata
+  user_metadata: UserMetadata
   aud: string
   confirmation_sent_at?: string
   recovery_sent_at?: string


### PR DESCRIPTION
By using named types for `app_metadata` and `user_metadata` developers can use [TypeScript declaration merging](https://www.typescriptlang.org/docs/handbook/declaration-merging.html) to enforce some form of type checking on these fields.

See: #241.

(Same as #464 but for next branch.)