### PR TITLE
feat: update setSession

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -17,6 +17,7 @@ import {
 } from './lib/errors'
 import { Fetch, _request, _sessionResponse, _userResponse } from './lib/fetch'
 import {
+  decodeBase64URL,
   Deferred,
   getItemAsync,
   getParameterByName,
@@ -544,14 +545,7 @@ export default class GoTrueClient {
       let hasExpired = true
       let session: Session | null = null
       if (currentSession.access_token && currentSession.access_token.split('.')[1]) {
-        const payload = JSON.parse(
-          atob(
-            currentSession.access_token
-              .split('.')[1]
-              .replaceAll(/[-]/g, '+')
-              .replaceAll(/[_]/g, '/')
-          )
-        )
+        const payload = JSON.parse(decodeBase64URL(currentSession.access_token.split('.')[1]))
         if (payload.exp) {
           expiresAt = payload.exp
           hasExpired = expiresAt <= timeNow

--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -545,7 +545,12 @@ export default class GoTrueClient {
       let session: Session | null = null
       if (currentSession.access_token && currentSession.access_token.split('.')[1]) {
         const payload = JSON.parse(
-          Buffer.from(currentSession.access_token.split('.')[1], 'base64').toString()
+          atob(
+            currentSession.access_token
+              .split('.')[1]
+              .replaceAll(/[-]/g, '+')
+              .replaceAll(/[_]/g, '/')
+          )
         )
         if (payload.exp) {
           expiresAt = payload.exp

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -78,6 +78,24 @@ export const removeItemAsync = async (storage: SupportedStorage, key: string): P
   await storage.removeItem(key)
 }
 
+export const decodeBase64URL = (value: string): string => {
+  try {
+    // atob is present in all browsers and nodejs >= 16
+    // but if it is not it will throw a ReferenceError in which case we can try to use Buffer
+    // replace are here to convert the Base64-URL into Base64 which is what atob supports
+    // replace with //g regex acts like replaceAll
+    return atob(value.replace(/[-]/g, '+').replace(/[_]/g, '/'))
+  } catch (e) {
+    if (e instanceof ReferenceError) {
+      // running on nodejs < 16
+      // Buffer supports Base64-URL transparently
+      return Buffer.from(value, 'base64').toString('utf-8')
+    } else {
+      throw e
+    }
+  }
+}
+
 /**
  * A deferred represents some asynchronous work that is not yet finished, which
  * may or may not culminate in a value.

--- a/test/GoTrueClient.test.ts
+++ b/test/GoTrueClient.test.ts
@@ -30,7 +30,8 @@ describe('GoTrueClient', () => {
       expect(error).toBeNull()
       expect(data.session).not.toBeNull()
 
-      await authWithSession.setSession(data.session?.refresh_token as string)
+      // @ts-expect-error 'data.session should not be null because of the assertion above'
+      await authWithSession.setSession(data.session)
       const {
         data: { user },
         error: updateError,

--- a/test/GoTrueClient.test.ts
+++ b/test/GoTrueClient.test.ts
@@ -30,8 +30,24 @@ describe('GoTrueClient', () => {
       expect(error).toBeNull()
       expect(data.session).not.toBeNull()
 
-      // @ts-expect-error 'data.session should not be null because of the assertion above'
-      await authWithSession.setSession(data.session)
+      const {
+        data: { session },
+        error: setSessionError,
+      } = await authWithSession.setSession({
+        // @ts-expect-error 'data.session should not be null because of the assertion above'
+        access_token: data.session.access_token,
+        // @ts-expect-error 'data.session should not be null because of the assertion above'
+        refresh_token: data.session.refresh_token,
+      })
+      expect(setSessionError).toBeNull()
+      expect(session).not.toBeNull()
+      expect(session!.user).not.toBeNull()
+      expect(session!.expires_in).not.toBeNull()
+      expect(session!.expires_at).not.toBeNull()
+      expect(session!.access_token).not.toBeNull()
+      expect(session!.refresh_token).not.toBeNull()
+      expect(session!.token_type).toStrictEqual('bearer')
+
       const {
         data: { user },
         error: updateError,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,6 @@
     "rootDir": "src",
     "sourceMap": true,
     "target": "ES2015",
-    "lib": ["ES2021.String"],
 
     "strict": true,
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "rootDir": "src",
     "sourceMap": true,
     "target": "ES2015",
+    "lib": ["ES2021.String"],
 
     "strict": true,
 
@@ -18,6 +19,6 @@
     "stripInternal": true
   },
   "typedocOptions": {
-    "excludeExternals": true,
+    "excludeExternals": true
   }
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Fixes `setSession` to make it safe to use in a server-side or SSR context
* `setSession` should take in an `access token` and `refresh token` and only perform a refresh if the `access_token` is expired. We derive the expiry from the `exp` claim in the `access_token`.  
* This is a breaking change because `setSession` now takes in an object.
* References #445 but made some changes to make it compatible for v2
