### PR TITLE
fix: getUser should default to authorization header

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -478,7 +478,7 @@ export default class GoTrueClient {
         }
 
         // Default to Authorization header if there is no existing session
-        jwt = data.session?.access_token ?? this.headers['Authorization']
+        jwt = data.session?.access_token ?? undefined
       }
 
       return await _request(this.fetch, 'GET', `${this.url}/user`, {


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Fixes this [issue](https://github.com/supabase/gotrue-js/issues/450#issuecomment-1261628057) where setting the `Authorization` header when the client is created doesn't get used properly in `getUser` 
* The problem was due to the jwt being overridden in the `Authorization` header in the `_request` function (https://github.com/supabase/gotrue-js/blob/rc/src/lib/fetch.ts#L84-L87) 