### PR TITLE
refactor: getAuthenticatorAssuranceLevel method

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -687,7 +687,7 @@ export type AuthMFAGetAuthenticatorAssuranceLevelResponse =
          * the information here to detect the last time a user verified a
          * factor, for example if implementing a step-up scenario.
          */
-        currentAuthenticationMethods: AMREntry[] | null
+        currentAuthenticationMethods: AMREntry[]
       }
       error: null
     }


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Return empty array instead of null for `currentAuthenticationMethods` field if session is null