### PR TITLE
fix: listFactors should use getUser

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -1143,14 +1143,17 @@ export default class GoTrueClient {
    * Displays all devices for a given user
    */
   private async _listFactors(): Promise<AuthMFAListFactorsResponse> {
-    const { data: sessionData, error: sessionError } = await this.getSession()
-    if (sessionError) {
-      return { data: null, error: sessionError }
+    const {
+      data: { user },
+      error: userError,
+    } = await this.getUser()
+    if (userError) {
+      return { data: null, error: userError }
     }
 
-    const factors = sessionData?.session?.user?.factors || []
+    const factors = user?.factors || []
     const totp = factors.filter(
-      (factor) => 'totp' === factor.factor_type && 'verified' === factor.status
+      (factor) => factor.factor_type === 'totp' && factor.status === 'verified'
     )
 
     return {


### PR DESCRIPTION
## What kind of change does this PR introduce?
* `listFactors` should not read the factors from the JWT since it could be stale, it should always make a request to the /user endpoint to get the user and return the factors