### PR TITLE
fix: add forgotten `data` option for sign ins

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -204,7 +204,7 @@ export default class GoTrueClient {
           body: {
             email,
             password,
-            data: options?.data,
+            data: options?.data ?? {},
             gotrue_meta_security: { captcha_token: options?.captchaToken },
           },
           xform: _sessionResponse,
@@ -216,7 +216,7 @@ export default class GoTrueClient {
           body: {
             phone,
             password,
-            data: options?.data,
+            data: options?.data ?? {},
             gotrue_meta_security: { captcha_token: options?.captchaToken },
           },
           xform: _sessionResponse,
@@ -266,6 +266,7 @@ export default class GoTrueClient {
           body: {
             email,
             password,
+            data: options?.data ?? {},
             gotrue_meta_security: { captcha_token: options?.captchaToken },
           },
           xform: _sessionResponse,
@@ -277,6 +278,7 @@ export default class GoTrueClient {
           body: {
             phone,
             password,
+            data: options?.data ?? {},
             gotrue_meta_security: { captcha_token: options?.captchaToken },
           },
           xform: _sessionResponse,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -300,6 +300,12 @@ export type SignInWithPasswordCredentials =
       /** The user's password. */
       password: string
       options?: {
+        /**
+         * A custom data object to store the user's metadata. This maps to the `auth.users.user_metadata` column.
+         *
+         * The `data` should be a JSON object that includes user-specific info, such as their first and last name.
+         */
+        data?: object
         /** Verification token received when the user completes the captcha on the site. */
         captchaToken?: string
       }
@@ -310,6 +316,12 @@ export type SignInWithPasswordCredentials =
       /** The user's password. */
       password: string
       options?: {
+        /**
+         * A custom data object to store the user's metadata. This maps to the `auth.users.user_metadata` column.
+         *
+         * The `data` should be a JSON object that includes user-specific info, such as their first and last name.
+         */
+        data?: object
         /** Verification token received when the user completes the captcha on the site. */
         captchaToken?: string
       }


### PR DESCRIPTION
`data` options were forgotten for some sign in methods.