### PR TITLE
fix: remove xform on admin mfa methods

### DIFF
--- a/src/GoTrueAdminApi.ts
+++ b/src/GoTrueAdminApi.ts
@@ -251,7 +251,6 @@ export default class GoTrueAdminApi {
         `${this.url}/admin/users/${params.userId}/factors`,
         {
           headers: this.headers,
-          xform: _userResponse,
         }
       )
       return { data, error: null }
@@ -274,7 +273,6 @@ export default class GoTrueAdminApi {
         `${this.url}/admin/users/${params.userId}/factors/${params.id}`,
         {
           headers: this.headers,
-          xform: _userResponse,
         }
       )
 


### PR DESCRIPTION
fix #514 by removing the xform(transform) applied to the result of querying the `listFactors` and `deleteFactors` end points. This would mean that the response would be returned without any transformation applied to it