### PR TITLE
fix: use `captcha_token` in `verifyOtp`

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -401,7 +401,7 @@ export default class GoTrueClient {
         headers: this.headers,
         body: {
           ...params,
-          gotrue_meta_security: { captchaToken: params.options?.captchaToken },
+          gotrue_meta_security: { captcha_token: params.options?.captchaToken },
         },
         redirectTo: params.options?.redirectTo,
         xform: _sessionResponse,


### PR DESCRIPTION
It's sending `captchaToken` to GoTrue which needs to be snake case. Ouch.