### PR TITLE
feat: add `signInWithSSO` method as `@experimental`

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -15,7 +15,7 @@ import {
   AuthUnknownError,
   isAuthError,
 } from './lib/errors'
-import { Fetch, _request, _sessionResponse, _userResponse } from './lib/fetch'
+import { Fetch, _request, _sessionResponse, _userResponse, _ssoResponse } from './lib/fetch'
 import {
   Deferred,
   getItemAsync,
@@ -36,11 +36,13 @@ import type {
   GoTrueClientOptions,
   InitializeResult,
   OAuthResponse,
+  SSOResponse,
   Provider,
   Session,
   SignInWithOAuthCredentials,
   SignInWithPasswordCredentials,
   SignInWithPasswordlessCredentials,
+  SignInWithSSO,
   SignUpWithPasswordCredentials,
   Subscription,
   SupportedStorage,
@@ -429,6 +431,50 @@ export default class GoTrueClient {
         return { data: { user: null, session: null }, error }
       }
 
+      throw error
+    }
+  }
+
+  /**
+   * Attempts a single-sign on using an enterprise Identity Provider. A
+   * successful SSO attempt will redirect the current page to the identity
+   * provider authorization page. The redirect URL is implementation and SSO
+   * protocol specific.
+   *
+   * You can use it by providing a SSO domain. Typically you can extract this
+   * domain by asking users for their email address. If this domain is
+   * registered on the Auth instance the redirect will use that organization's
+   * currently active SSO Identity Provider for the login.
+   *
+   * If you have built an organization-specific login page, you can use the
+   * organization's SSO Identity Provider UUID directly instead.
+   *
+   * This API is experimental and availability is conditional on correct
+   * settings on the Auth service.
+   *
+   * @experimental
+   */
+  async signInWithSSO(params: SignInWithSSO): Promise<SSOResponse> {
+    try {
+      await this._removeSession()
+
+      return await _request(this.fetch, 'POST', `${this.url}/sso`, {
+        body: {
+          ...('providerId' in params ? { provider_id: params.providerId } : null),
+          ...('domain' in params ? { domain: params.domain } : null),
+          redirect_to: params.options?.redirectTo ?? undefined,
+          ...(params?.options?.captchaToken
+            ? { gotrue_meta_security: { captcha_token: params.options.captchaToken } }
+            : null),
+          skip_http_redirect: true, // fetch does not handle redirects
+        },
+        headers: this.headers,
+        xform: _ssoResponse,
+      })
+    } catch (error) {
+      if (isAuthError(error)) {
+        return { data: null, error }
+      }
       throw error
     }
   }

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -1,6 +1,7 @@
 import { expiresAt, looksLikeFetchResponse } from './helpers'
 import {
   AuthResponse,
+  SSOResponse,
   GenerateLinkProperties,
   GenerateLinkResponse,
   User,
@@ -134,6 +135,10 @@ export function _sessionResponse(data: any): AuthResponse {
 export function _userResponse(data: any): UserResponse {
   const user: User = data.user ?? (data as User)
   return { data: { user }, error: null }
+}
+
+export function _ssoResponse(data: any): SSOResponse {
+  return { data, error: null }
 }
 
 export function _generateLinkResponse(data: any): GenerateLinkResponse {

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -88,7 +88,7 @@ export const decodeBase64URL = (value: string): string => {
     return decodeURIComponent(
       atob(value.replace(/[-]/g, '+').replace(/[_]/g, '/'))
         .split('')
-        .map(c => '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2))
+        .map((c) => '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2))
         .join('')
     )
   } catch (e) {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -85,6 +85,19 @@ export type OAuthResponse =
       error: AuthError
     }
 
+export type SSOResponse =
+  | {
+      data: {
+        /** URL to take the user to (in a browser) to complete SSO. */
+        url: string
+      }
+      error: null
+    }
+  | {
+      data: null
+      error: AuthError
+    }
+
 export type UserResponse =
   | {
       data: {
@@ -466,6 +479,24 @@ export interface VerifyEmailOtpParams {
 export type MobileOtpType = 'sms' | 'phone_change'
 export type EmailOtpType = 'signup' | 'invite' | 'magiclink' | 'recovery' | 'email_change'
 
+export type SignInWithSSO = {
+  options?: {
+    /** A URL to send the user to after they have signed-in. */
+    redirectTo?: string
+    /** Verification token received when the user completes the captcha on the site. */
+    captchaToken?: string
+  }
+} & (
+  | {
+      /** UUID of the SSO provider to invoke single-sign on to. */
+      providerId: string
+    }
+  | {
+      /** Domain name of the organization for which to invoke single-sign on. */
+      domain: string
+    }
+)
+
 export type GenerateSignupLinkParams = {
   type: 'signup'
   email: string
@@ -805,7 +836,7 @@ export interface GoTrueMFAApi {
    */
   unenroll(params: MFAUnenrollParams): Promise<AuthMFAUnenrollResponse>
 
-/**
+  /**
    * Helper method which creates a challenge and immediately uses the given code to verify against it thereafter. The verification code is
    * provided by the user by entering a code seen in their authenticator app.
    *


### PR DESCRIPTION
Adds a new `signInWithSSO` method as `@experimental` with which you can initiate Single Sign-On logic.