### PR TITLE
fix: the deleteUser endpoint not return user data

### DIFF
--- a/src/GoTrueAdminApi.ts
+++ b/src/GoTrueAdminApi.ts
@@ -226,11 +226,10 @@ export default class GoTrueAdminApi {
    *
    * This function should only be called on a server. Never expose your `service_role` key in the browser.
    */
-  async deleteUser(id: string): Promise<UserResponse> {
+  async deleteUser(id: string): Promise<{ data: null; error: AuthError | null }> {
     try {
       return await _request(this.fetch, 'DELETE', `${this.url}/admin/users/${id}`, {
         headers: this.headers,
-        xform: _userResponse,
       })
     } catch (error) {
       if (isAuthError(error)) {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Currently, the `deleteUser` method of `AdminApi` returns a response typed as a `UserResponse`, but it is actually an empty object.

## What is the new behavior?

Now only an `AuthError` is returned if it exists.

## Additional context

Code of `GoTrue` server-side

https://github.com/supabase/gotrue/blob/fc6f58d1437f896e893c8c93d122cefa8c3546ac/api/admin.go#L402
