### PR TITLE
fix: revert "fix: respect `EXPIRY_MARGIN` on `getSession`"

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -481,9 +481,8 @@ export default class GoTrueClient {
       return { data: { session: null }, error: null }
     }
 
-    const timeNow = Math.round(Date.now() / 1000);
     const hasExpired = currentSession.expires_at
-      ? currentSession.expires_at <= timeNow + EXPIRY_MARGIN
+      ? currentSession.expires_at <= Date.now() / 1000
       : false
     if (!hasExpired) {
       return { data: { session: currentSession }, error: null }


### PR DESCRIPTION
Reverts supabase/gotrue-js#482 because #529 is causing a larger scale issue.