### PR TITLE
feat: support pagination options for `listUsers()` method

### DIFF
--- a/src/GoTrueAdminApi.ts
+++ b/src/GoTrueAdminApi.ts
@@ -163,7 +163,7 @@ export default class GoTrueAdminApi {
   > {
     
     try {
-     const { data, error } = await _request(this.fetch, 'GET', `${this.url}/admin/users`, {
+      const { data, error } = await _request(this.fetch, 'GET', `${this.url}/admin/users`, {
         headers: this.headers,
         query: params,
       })

--- a/src/GoTrueAdminApi.ts
+++ b/src/GoTrueAdminApi.ts
@@ -157,19 +157,16 @@ export default class GoTrueAdminApi {
    * Get a list of users.
    *
    * This function should only be called on a server. Never expose your `service_role` key in the browser.
-   * @param params An object which supports `page` and `per_page` as numbers, to alter the paginated results.
+   * @param params An object which supports `page` and `per_page` as strings, to alter the paginated results.
    */
   async listUsers(params?: PageParams): Promise<
     { data: { users: User[] }; error: null } | { data: { users: [] }; error: AuthError }
   > {
-    let pageParams = ''
-    if (params) {
-      pageParams = params.page && params.per_page ? `?page=${params.page}&per_page=${params.per_page}` : params.page ? `?page=${params.page}` : params.per_page ? `?per_page=${params.per_page}` : ''
-    }
     
     try {
-     const { data, error } = await _request(this.fetch, 'GET', `${this.url}/admin/users${pageParams}`, {
+     const { data, error } = await _request(this.fetch, 'GET', `${this.url}/admin/users`, {
         headers: this.headers,
+        query: params,
       })
       if (error) throw error
       return { data: { ...data }, error: null }

--- a/src/GoTrueAdminApi.ts
+++ b/src/GoTrueAdminApi.ts
@@ -12,6 +12,7 @@ import {
   AuthMFAAdminDeleteFactorResponse,
   AuthMFAAdminListFactorsParams,
   AuthMFAAdminListFactorsResponse,
+  PageParams,
 } from './lib/types'
 import { AuthError, isAuthError } from './lib/errors'
 
@@ -156,12 +157,14 @@ export default class GoTrueAdminApi {
    * Get a list of users.
    *
    * This function should only be called on a server. Never expose your `service_role` key in the browser.
+   * @param params An object which supports `page` and `per_page` as numbers, to alter the paginated results.
    */
-  async listUsers(): Promise<
+  async listUsers(params: PageParams): Promise<
     { data: { users: User[] }; error: null } | { data: { users: [] }; error: AuthError }
   > {
+    const pageParams = params.page && params.per_page ? `?page=${params.page}&per_page=${params.per_page}` : params.page ? `?page=${params.page}` : params.per_page ? `?per_page=${params.per_page}` : ''
     try {
-      const { data, error } = await _request(this.fetch, 'GET', `${this.url}/admin/users`, {
+     const { data, error } = await _request(this.fetch, 'GET', `${this.url}/admin/users${pageParams}`, {
         headers: this.headers,
       })
       if (error) throw error

--- a/src/GoTrueAdminApi.ts
+++ b/src/GoTrueAdminApi.ts
@@ -159,10 +159,14 @@ export default class GoTrueAdminApi {
    * This function should only be called on a server. Never expose your `service_role` key in the browser.
    * @param params An object which supports `page` and `per_page` as numbers, to alter the paginated results.
    */
-  async listUsers(params: PageParams): Promise<
+  async listUsers(params?: PageParams): Promise<
     { data: { users: User[] }; error: null } | { data: { users: [] }; error: AuthError }
   > {
-    const pageParams = params.page && params.per_page ? `?page=${params.page}&per_page=${params.per_page}` : params.page ? `?page=${params.page}` : params.per_page ? `?per_page=${params.per_page}` : ''
+    let pageParams = ''
+    if (params) {
+      pageParams = params.page && params.per_page ? `?page=${params.page}&per_page=${params.per_page}` : params.page ? `?page=${params.page}` : params.per_page ? `?per_page=${params.per_page}` : ''
+    }
+    
     try {
      const { data, error } = await _request(this.fetch, 'GET', `${this.url}/admin/users${pageParams}`, {
         headers: this.headers,

--- a/src/GoTrueAdminApi.ts
+++ b/src/GoTrueAdminApi.ts
@@ -164,7 +164,7 @@ export default class GoTrueAdminApi {
     try {
       const { data, error } = await _request(this.fetch, 'GET', `${this.url}/admin/users`, {
         headers: this.headers,
-        query: params,
+        query: { page: params?.page ?? '', per_page: params?.perPage ?? '' },
       })
       if (error) throw error
       return { data: { ...data }, error: null }

--- a/src/GoTrueAdminApi.ts
+++ b/src/GoTrueAdminApi.ts
@@ -161,7 +161,6 @@ export default class GoTrueAdminApi {
   async listUsers(params?: PageParams): Promise<
     { data: { users: User[] }; error: null } | { data: { users: [] }; error: AuthError }
   > {
-    
     try {
       const { data, error } = await _request(this.fetch, 'GET', `${this.url}/admin/users`, {
         headers: this.headers,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -972,6 +972,6 @@ export type CallRefreshTokenResult =
     }
 
 export type PageParams = {
-  page?: number,
-  per_page?: number
+  page?: string,
+  per_page?: string
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -972,6 +972,6 @@ export type CallRefreshTokenResult =
     }
 
 export type PageParams = {
-  page?: string,
-  per_page?: string
+  page?: number,
+  perPage?: number
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -970,3 +970,8 @@ export type CallRefreshTokenResult =
       session: null
       error: AuthError
     }
+
+export type PageParams = {
+  page?: number,
+  per_page?: number
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Allows you to pass in a `params` object to `listUsers()`; to determine paginated results. 

## What is the current behavior?

`listUsers()` will only return the first 50 results.

## What is the new behavior?

Introduces an options object to `listUsers()`. The two options are `page` and `per_page`. They can be used together or individually. These option names are consistent with the api code found [here](https://github.com/supabase/gotrue/blob/930f5affdab112db81e17ef799418206bead9092/api/pagination.go#L42-L43).

`page` - which page of paginated results to return
`per_page` - how many results to return per page

Example:
```js
const { data, error } = await client.auth.admin.listUsers({ page: '2', per_page: '100' })
```

## Additional context

`params` option name was based on existing usage like [this](https://github.com/supabase/gotrue-js/blob/master/src/GoTrueAdminApi.ts#L105) code.
`PageParams` type name was based on [this](https://github.com/supabase/gotrue/blob/master/api/admin.go#L103) code.

Closes https://github.com/supabase/gotrue-js/issues/538.
