### PR TITLE
Fix incorrect behavior of the isBrowser() function and relative functionality

### DIFF
--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -13,7 +13,7 @@ export function uuid() {
   })
 }
 
-export const isBrowser = () => typeof window !== 'undefined'
+export const isBrowser = () => typeof document !== 'undefined'
 
 export function getParameterByName(name: string, url?: string) {
   if (!url) url = window?.location?.href || ''


### PR DESCRIPTION

## What kind of change does this PR introduce?

This change fixes incorrect behavior of the `isBrowser()` function and relative functionality.

## What is the current behavior?

Currently, the `isBrowser()` function returns `true` in React Native environment on mobile devices. That is obviously wrong. 

Relevant issues: #495 and https://github.com/supabase/supabase/issues/3790

## What is the new behavior?

After the fix, the `isBrowser()` function will return `false` when running in React Native environment and will continue returning `false` when running in Node.
