### PR TITLE
fix: setSession is in broken state after v2.4.0

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -665,6 +665,7 @@ export default class GoTrueClient {
           expires_in: expiresAt - timeNow,
           expires_at: expiresAt,
         }
+        await this._saveSession(session)
       }
 
       return { data: { user: session.user, session }, error: null }

--- a/test/GoTrueClient.test.ts
+++ b/test/GoTrueClient.test.ts
@@ -98,6 +98,15 @@ describe('GoTrueClient', () => {
       expect(error).toBeNull()
       expect(data.session).not.toBeNull()
 
+      /** 
+       * Sign out the user to verify setSession, getSession and updateUser
+       * are truly working; because the signUp method will already save the session.
+       * And that session will be available to getSession and updateUser,
+       * even if setSession isn't called or fails to save the session.
+       * The tokens are still valid after logout, and therefore usable.
+       */
+      await authWithSession.signOut()
+
       const {
         data: { session },
         error: setSessionError,
@@ -115,6 +124,17 @@ describe('GoTrueClient', () => {
       expect(session!.access_token).not.toBeNull()
       expect(session!.refresh_token).not.toBeNull()
       expect(session!.token_type).toStrictEqual('bearer')
+
+      /**
+       * getSession has been added to verify setSession is also saving
+       * the session, not just returning it.
+       */
+      const { 
+        data: getSessionData, 
+        error: getSessionError 
+      } = await authWithSession.getSession()
+      expect(getSessionError).toBeNull()
+      expect(getSessionData).not.toBeNull()
 
       const {
         data: { user },


### PR DESCRIPTION
## What kind of change does this PR introduce?

@kangmingtay, bit of a critical here. Completely my fault.

Fixes a critical issue with `setSession()`. With the errant code, as part of #536, if a token hasn't expired, the session is returned but never gets saved. I removed a line when consolidating, but it should've been moved up instead. I completely missed this, and I apologize.

Thanks to someone else for finding this! https://github.com/supabase/gotrue-js/issues/539#issuecomment-1334692479

## Additional Context

Also tweaks the existing setSession test, to ensure the method is saving the session. This would've caught my coding error.