### PR TITLE
feat(gotrue/client): add noResolveJson options in GoTrueClient constructor

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -77,6 +77,7 @@ const DEFAULT_OPTIONS: Omit<Required<GoTrueClientOptions>, 'fetch' | 'storage'> 
   persistSession: true,
   detectSessionInUrl: true,
   headers: DEFAULT_HEADERS,
+  noResolveJsonOnFetchedResponse: false
 }
 
 export default class GoTrueClient {
@@ -120,6 +121,7 @@ export default class GoTrueClient {
     [key: string]: string
   }
   protected fetch: Fetch
+  protected noResolveJsonOnFetchedResponse: boolean
 
   /**
    * Create a new client for use in the browser.
@@ -140,6 +142,7 @@ export default class GoTrueClient {
     this.url = settings.url
     this.headers = settings.headers
     this.fetch = resolveFetch(settings.fetch)
+    this.noResolveJsonOnFetchedResponse = settings.noResolveJsonOnFetchedResponse || false
     this.detectSessionInUrl = settings.detectSessionInUrl
 
     this.initialize()
@@ -239,6 +242,7 @@ export default class GoTrueClient {
             gotrue_meta_security: { captcha_token: options?.captchaToken },
           },
           xform: _sessionResponse,
+          noResolveJson: this.noResolveJsonOnFetchedResponse,
         })
       } else if ('phone' in credentials) {
         const { phone, password, options } = credentials
@@ -251,6 +255,7 @@ export default class GoTrueClient {
             gotrue_meta_security: { captcha_token: options?.captchaToken },
           },
           xform: _sessionResponse,
+          noResolveJson: this.noResolveJsonOnFetchedResponse,
         })
       } else {
         throw new AuthInvalidCredentialsError(
@@ -301,6 +306,7 @@ export default class GoTrueClient {
             gotrue_meta_security: { captcha_token: options?.captchaToken },
           },
           xform: _sessionResponse,
+          noResolveJson: this.noResolveJsonOnFetchedResponse,
         })
       } else if ('phone' in credentials) {
         const { phone, password, options } = credentials
@@ -313,6 +319,7 @@ export default class GoTrueClient {
             gotrue_meta_security: { captcha_token: options?.captchaToken },
           },
           xform: _sessionResponse,
+          noResolveJson: this.noResolveJsonOnFetchedResponse,
         })
       } else {
         throw new AuthInvalidCredentialsError(
@@ -367,6 +374,7 @@ export default class GoTrueClient {
             gotrue_meta_security: { captcha_token: options?.captchaToken },
           },
           redirectTo: options?.emailRedirectTo,
+          noResolveJson: this.noResolveJsonOnFetchedResponse,
         })
         return { data: { user: null, session: null }, error }
       }
@@ -380,6 +388,7 @@ export default class GoTrueClient {
             create_user: options?.shouldCreateUser ?? true,
             gotrue_meta_security: { captcha_token: options?.captchaToken },
           },
+          noResolveJson: this.noResolveJsonOnFetchedResponse,
         })
         return { data: { user: null, session: null }, error }
       }
@@ -408,6 +417,7 @@ export default class GoTrueClient {
         },
         redirectTo: params.options?.redirectTo,
         xform: _sessionResponse,
+        noResolveJson: this.noResolveJsonOnFetchedResponse,
       })
 
       if (error) {
@@ -471,6 +481,7 @@ export default class GoTrueClient {
         },
         headers: this.headers,
         xform: _ssoResponse,
+        noResolveJson: this.noResolveJsonOnFetchedResponse,
       })
     } catch (error) {
       if (isAuthError(error)) {
@@ -563,6 +574,7 @@ export default class GoTrueClient {
         headers: this.headers,
         jwt: jwt,
         xform: _userResponse,
+        noResolveJson: this.noResolveJsonOnFetchedResponse,
       })
     } catch (error) {
       if (isAuthError(error)) {
@@ -591,6 +603,7 @@ export default class GoTrueClient {
         body: attributes,
         jwt: session.access_token,
         xform: _userResponse,
+        noResolveJson: this.noResolveJsonOnFetchedResponse,
       })
       if (userError) throw userError
       session.user = data.user as User
@@ -872,6 +885,7 @@ export default class GoTrueClient {
         body: { email, gotrue_meta_security: { captcha_token: options.captchaToken } },
         headers: this.headers,
         redirectTo: options.redirectTo,
+        noResolveJson: this.noResolveJsonOnFetchedResponse,
       })
     } catch (error) {
       if (isAuthError(error)) {
@@ -892,6 +906,7 @@ export default class GoTrueClient {
         body: { refresh_token: refreshToken },
         headers: this.headers,
         xform: _sessionResponse,
+        noResolveJson: this.noResolveJsonOnFetchedResponse,
       })
     } catch (error) {
       if (isAuthError(error)) {
@@ -1149,6 +1164,7 @@ export default class GoTrueClient {
       return await _request(this.fetch, 'DELETE', `${this.url}/factors/${params.factorId}`, {
         headers: this.headers,
         jwt: sessionData?.session?.access_token,
+        noResolveJson: this.noResolveJsonOnFetchedResponse,
       })
     } catch (error) {
       if (isAuthError(error)) {
@@ -1179,6 +1195,7 @@ export default class GoTrueClient {
         },
         headers: this.headers,
         jwt: sessionData?.session?.access_token,
+        noResolveJson: this.noResolveJsonOnFetchedResponse,
       })
 
       if (error) {
@@ -1218,6 +1235,7 @@ export default class GoTrueClient {
           body: { code: params.code, challenge_id: params.challengeId },
           headers: this.headers,
           jwt: sessionData?.session?.access_token,
+          noResolveJson: this.noResolveJsonOnFetchedResponse,
         }
       )
       if (error) {
@@ -1257,6 +1275,7 @@ export default class GoTrueClient {
         {
           headers: this.headers,
           jwt: sessionData?.session?.access_token,
+          noResolveJson: this.noResolveJsonOnFetchedResponse,
         }
       )
     } catch (error) {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -47,7 +47,9 @@ export type GoTrueClientOptions = {
   /* Provide your own local storage implementation to use instead of the browser's local storage. */
   storage?: SupportedStorage
   /* A custom fetch implementation. */
-  fetch?: Fetch
+  fetch?: Fetch,
+  /* Set to "true" if you want your response through a custom fetch implementation to be converted to JSON through `.json()` function */
+  noResolveJsonOnFetchedResponse?: boolean
 }
 
 export type AuthResponse =

--- a/test/GoTrueClient.test.ts
+++ b/test/GoTrueClient.test.ts
@@ -1,4 +1,5 @@
 import { AuthError } from '../src/lib/errors'
+import * as fetch from '../src/lib/fetch'
 import {
   authClient as auth,
   authClientWithSession as authWithSession,
@@ -7,6 +8,7 @@ import {
   clientApiAutoConfirmDisabledClient as signUpDisabledClient,
   clientApiAutoConfirmEnabledClient as signUpEnabledClient,
   authAdminApiAutoConfirmEnabledClient,
+  clientApiWithNoResolveJson
 } from './lib/clients'
 import { mockUserCredentials } from './lib/utils'
 
@@ -900,5 +902,22 @@ describe('User management', () => {
     expect(error).toBeNull()
     expect(user).not.toBeNull()
     expect(user?.email).toEqual(email)
+  })
+})
+
+describe('Any API call with noResolveJson set to true', () => {
+  test('', async () => {
+    const spiedRequest = jest.spyOn(fetch, '_request');
+
+    const { email, password } = mockUserCredentials()
+
+    const { error, data } = await clientApiWithNoResolveJson.signUp({
+      email,
+      password,
+    })
+
+    expect(error).toBeNull()
+    expect(data.session).not.toBeNull()
+    expect(spiedRequest).toHaveBeenCalled();
   })
 })

--- a/test/lib/clients.ts
+++ b/test/lib/clients.ts
@@ -56,6 +56,13 @@ export const clientApiAutoConfirmDisabledClient = new GoTrueClient({
   persistSession: true,
 })
 
+export const clientApiWithNoResolveJson = new GoTrueClient({
+  url: GOTRUE_URL_SIGNUP_ENABLED_AUTO_CONFIRM_ON,
+  autoRefreshToken: false,
+  persistSession: true,
+  noResolveJsonOnFetchedResponse: true
+})
+
 export const authAdminApiAutoConfirmEnabledClient = new GoTrueAdminApi({
   url: GOTRUE_URL_SIGNUP_ENABLED_AUTO_CONFIRM_ON,
   headers: {


### PR DESCRIPTION
## What kind of change does this PR introduce?

This is a new feature, implementing the parameter `noResolveJson` that will be used in `_handleRequest` function in https://github.com/supabase/gotrue-js/blob/master/src/lib/fetch.ts#L79

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
