### PR TITLE
fix: remove comments about calling `getUser()` in listFactors()

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -794,10 +794,8 @@ export interface GoTrueMFAApi {
   challengeAndVerify(params: MFAChallengeAndVerifyParams): Promise<AuthMFAVerifyResponse>
 
   /**
-   * Returns the list of MFA factors enabled for this user. For most use cases
-   * you should consider using {@link
-   * GoTrueMFAApi#getAuthenticatorAssuranceLevel}. This uses a cached version
-   * of the factors and avoids incurring a network call.
+   * Returns the list of MFA factors enabled for this user. This uses a cached version
+   * of the factors retrieved from the user's access token JWT to avoid incurring a network call.
    *
    * @see {@link GoTrueMFAApi#enroll}
    * @see {@link GoTrueMFAApi#getAuthenticatorAssuranceLevel}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -794,8 +794,7 @@ export interface GoTrueMFAApi {
   challengeAndVerify(params: MFAChallengeAndVerifyParams): Promise<AuthMFAVerifyResponse>
 
   /**
-   * Returns the list of MFA factors enabled for this user. This uses a cached version
-   * of the factors retrieved from the user's access token JWT to avoid incurring a network call.
+   * Returns the list of MFA factors enabled for this user.
    *
    * @see {@link GoTrueMFAApi#enroll}
    * @see {@link GoTrueMFAApi#getAuthenticatorAssuranceLevel}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -797,8 +797,7 @@ export interface GoTrueMFAApi {
    * Returns the list of MFA factors enabled for this user. For most use cases
    * you should consider using {@link
    * GoTrueMFAApi#getAuthenticatorAssuranceLevel}. This uses a cached version
-   * of the factors and avoids incurring a network call. If you need to update
-   * this list, call {@link GoTrueClient#getUser} first.
+   * of the factors and avoids incurring a network call.
    *
    * @see {@link GoTrueMFAApi#enroll}
    * @see {@link GoTrueMFAApi#getAuthenticatorAssuranceLevel}


### PR DESCRIPTION
Since `getUser()` is being called within `listFactors()`, users shouldn't have to call `getUser()` by themselves to get the most up-to-date information. 

Also `listFactors()` does not seem to be documented in the [js docs](https://supabase.com/docs/reference/javascript/introduction), but should we add it?

Credit goes to @Vinzent03 for noticing these while working adding MFA support to the Flutter SDK 🎉