### PR TITLE
fix: use `location.assign()` instead of `location.href`

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -927,7 +927,7 @@ export default class GoTrueClient {
     })
     // try to open on the browser
     if (isBrowser()) {
-      window.location.href = url
+      window.location.assign(url)
     }
     return { data: { provider, url }, error: null }
   }


### PR DESCRIPTION
[`location.assign()`](https://developer.mozilla.org/en-US/docs/Web/API/Location/assign) has the same semantics as [`location.href = ...`](https://developer.mozilla.org/en-US/docs/Web/API/Location/href) but it's easier to stub out for integration tests and other things.

Fixes: #155 