### PR TITLE
feat: pop implicit flow URL from back stack

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -775,8 +775,8 @@ export default class GoTrueClient {
       }
       const redirectType = getParameterByName('type')
 
-      // Remove tokens from URL
-      window.location.hash = ''
+      // Remove tokens from URL and popping the URL from the back stack
+      window.location.replace(window.location.href.split('#')[0])
 
       return { data: { session, redirectType }, error: null }
     } catch (error) {


### PR DESCRIPTION
Uses [`window.location.replace()`]() instead of setting the `window.location.hash = ''` to ensure that the implicit flow URL is popped from the back stack and can't be navigated to.

Does not use the `history.replaceState()` API since this fragment is not a history-style fragment.

Fixes: #302.