### PR TITLE
feat: setSession triggers SIGNED_IN event

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -682,6 +682,7 @@ export default class GoTrueClient {
           expires_at: expiresAt,
         }
         await this._saveSession(session)
+        this._notifyAllSubscribers('SIGNED_IN', session)
       }
 
       return { data: { user: session.user, session }, error: null }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Introduces a new event trigger for the `setSession()` method.

## What is the current behavior?

Calling `setSession()` with a valid and non-expired session triggers no events.

## What is the new behavior?

Calling `setSession()` will trigger a `SIGNED_IN` event, if the session is valid. This will only happen if the session isn't expired - since an expired session would refresh the tokens and trigger a `TOKEN_REFRESHED` event.

## Additional context

Issues and discussions are coming up around this topic. Some implementations, including auth-helpers, rely on events being triggered in order to properly behave. After being involved in some of these discussions, triggering an event with `setSession()` makes sense to me. This is most relevant when using the method on the server-side, to "sign-in" a user - which, in my mind, is really what `setSession()` is doing. That's why I chose the `SIGNED_IN` event as the one to be triggered.

Expo - https://discord.com/channels/839993398554656828/1062010376155316224
React Native - https://discord.com/channels/839993398554656828/1060543536627453952
React/Next/Capacitor - https://github.com/supabase/supabase/discussions/11548

More validation that people understand this method as a way to sign-in a user. See `Expected behavior` section - https://github.com/supabase/supabase-js/issues/681

