### PR TITLE
feat: keep expired session on initialization

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -998,8 +998,6 @@ export default class GoTrueClient {
             console.log(error.message)
             await this._removeSession()
           }
-        } else {
-          await this._removeSession()
         }
       } else {
         if (this.persistSession) {


### PR DESCRIPTION
If a client is constructed when the underlying access token has expired and auto refresh is disabled, the session is getting removed. It should not be removed as the session can be automatically refreshed either with the auto refresh mechanism or whenever `getSession` is called next.