### PR TITLE
fix: remove data property from AdminUserAttributes

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -256,7 +256,7 @@ export interface UserAttributes {
   data?: object
 }
 
-export interface AdminUserAttributes extends UserAttributes {
+export interface AdminUserAttributes extends Omit<UserAttributes, 'data'> {
   /**
    * A custom data object to store the user's metadata. This maps to the `auth.users.user_metadata` column.
    *

--- a/test/lib/utils.ts
+++ b/test/lib/utils.ts
@@ -63,6 +63,6 @@ export const createNewUserWithEmail = async ({
   return await serviceRoleApiClient.createUser({
     email: newEmail,
     password: newPassword,
-    data: {},
+    user_metadata: {},
   })
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Remove the `data` property from the `AdminUserAttributes` type since it's unused 