### PR TITLE
Remove unused data field on signInWithPassword

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -323,7 +323,6 @@ export default class GoTrueClient {
           body: {
             email,
             password,
-            data: options?.data ?? {},
             gotrue_meta_security: { captcha_token: options?.captchaToken },
           },
           xform: _sessionResponse,
@@ -335,7 +334,6 @@ export default class GoTrueClient {
           body: {
             phone,
             password,
-            data: options?.data ?? {},
             gotrue_meta_security: { captcha_token: options?.captchaToken },
           },
           xform: _sessionResponse,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -368,12 +368,6 @@ export type SignInWithPasswordCredentials =
       /** The user's password. */
       password: string
       options?: {
-        /**
-         * A custom data object to store the user's metadata. This maps to the `auth.users.user_metadata` column.
-         *
-         * The `data` should be a JSON object that includes user-specific info, such as their first and last name.
-         */
-        data?: object
         /** Verification token received when the user completes the captcha on the site. */
         captchaToken?: string
       }


### PR DESCRIPTION
The data param to [signInWithPassword](https://github.com/supabase/gotrue-js/blob/master/src/GoTrueClient.ts#L326) ?
seems to be [not used in GoTrue](
https://github.com/supabase/gotrue/blob/master/internal/api/token.go#LL58C34-L58C34)
