### PR TITLE
feat: add support for whatsapp programmable messaging API

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -309,7 +309,10 @@ export default class GoTrueClient {
    * Be aware that you may get back an error message that will not distingish
    * between the cases where the account does not exist or that the
    * email/phone and password combination is wrong or that the account can only
-   * be accessed via social login.
+   * be accessed via social login. Do note that you will need
+   * to configure a Whatsapp sender on Twilio if you are using phone sign in
+   * with 'whatsapp'. The whatsapp channel is not supported on other providers
+   * at this time.
    */
   async signInWithPassword(credentials: SignInWithPasswordCredentials): Promise<AuthResponse> {
     try {
@@ -420,6 +423,11 @@ export default class GoTrueClient {
    * Be aware that you may get back an error message that will not distinguish
    * between the cases where the account does not exist or, that the account
    * can only be accessed via social login.
+   *
+   * Do note that you will need to configure a Whatsapp sender on Twilio
+   * if you are using phone sign in with the 'whatsapp' channel. The whatsapp
+   * channel is not supported on other providers
+   * at this time.
    */
   async signInWithOtp(credentials: SignInWithPasswordlessCredentials): Promise<AuthResponse> {
     try {

--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -447,6 +447,7 @@ export default class GoTrueClient {
             data: options?.data ?? {},
             create_user: options?.shouldCreateUser ?? true,
             gotrue_meta_security: { captcha_token: options?.captchaToken },
+            channel: options?.channel ?? 'sms',
           },
         })
         return { data: { user: null, session: null }, error }

--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -335,6 +335,7 @@ export default class GoTrueClient {
             phone,
             password,
             gotrue_meta_security: { captcha_token: options?.captchaToken },
+            channel: options?.channel ?? 'sms',
           },
           xform: _sessionResponse,
         })

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -422,6 +422,7 @@ export type SignInWithPasswordlessCredentials =
         data?: object
         /** Verification token received when the user completes the captcha on the site. */
         captchaToken?: string
+        channel?: string
       }
     }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -387,7 +387,7 @@ export type SignInWithPasswordCredentials =
         /** Verification token received when the user completes the captcha on the site. */
         captchaToken?: string
         /** Messaging channel to use (e.g. whatsapp or sms) */
-        channel?: string
+        channel?: 'sms' | 'whatsapp'
       }
     }
 
@@ -425,7 +425,7 @@ export type SignInWithPasswordlessCredentials =
         /** Verification token received when the user completes the captcha on the site. */
         captchaToken?: string
         /** Messaging channel to use (e.g. whatsapp or sms) */
-        channel?: string
+        channel?: 'sms' | 'whatsapp'
       }
     }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -386,6 +386,8 @@ export type SignInWithPasswordCredentials =
         data?: object
         /** Verification token received when the user completes the captcha on the site. */
         captchaToken?: string
+        /** Messaging channel to use (e.g. whatsapp or sms) */
+        channel?: string
       }
     }
 
@@ -422,6 +424,7 @@ export type SignInWithPasswordlessCredentials =
         data?: object
         /** Verification token received when the user completes the captcha on the site. */
         captchaToken?: string
+        /** Messaging channel to use (e.g. whatsapp or sms) */
         channel?: string
       }
     }


### PR DESCRIPTION
We wish to add support for the [Whatsapp Programmable Messaging API](https://www.twilio.com/docs/whatsapp/api) for Twilio and possibly for other providers in the near future.

This would allow users to send one time verification codes over Whatsapp instead of SMS which is arguably a more secure channel

Methods affected:
- `supabase.auth.signInWithPassword`
- `supabase.auth.signInWithOTP`

How to test

1. Clone  gotrue-js and checkout `j0/support-whatsapp`
2. Clone gotrue and checkout `j0/support-whatsapp`
3. Go to your app and change dependency to point to point to gotrue-js


```
supabsae.auth.signInWithOtp({ phone: '<your-special-number-with-international-code>', options: {
        channel: 'sms'}}))
```

```
supabase.auth.signInWithPassword({
   phone: '<your-special-number-with-international-code>',
   options: {
       channel: 'whatsapp'
   }
})
```

Note that if you supply an invalid channel or an API which doesn't support whatsapp it will default to the current behaviour which is SMS
