### PR TITLE
feat: make certain properties in `UserIdentity` nullable

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -161,12 +161,12 @@ export interface AMREntry {
 export interface UserIdentity {
   id: string
   user_id: string
-  identity_data: {
+  identity_data?: {
     [key: string]: any
   }
   provider: string
-  created_at: string
-  last_sign_in_at: string
+  created_at?: string
+  last_sign_in_at?: string
   updated_at?: string
 }
 


### PR DESCRIPTION
Based on some feedback recently, these properties should have been nullable/optional. Although this is a backward incompatible change, it is likely the codebases needing attention after this change is relatively minor.