### PR TITLE
fix: defer `notifyAllSubscribers` in the constructor

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -210,10 +210,13 @@ export default class GoTrueClient {
         const { session, redirectType } = data
 
         await this._saveSession(session)
-        this._notifyAllSubscribers('SIGNED_IN', session)
-        if (redirectType === 'recovery') {
-          this._notifyAllSubscribers('PASSWORD_RECOVERY', session)
-        }
+
+        setTimeout(() => {
+          this._notifyAllSubscribers('SIGNED_IN', session)
+          if (redirectType === 'recovery') {
+            this._notifyAllSubscribers('PASSWORD_RECOVERY', session)
+          }
+        }, 0)
 
         return { error: null }
       }


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Attempts to fix #518 , #615 

## What is the current behavior?
* During the instantiation of `GoTrueClient`, the constructor notifies all subscribers if it detects that there is an existing session. In some situations, `onAuthStateChange` is called much later in the callstack which results in the constructor notifying an empty list of subscribers before `onAuthStateChange` is able to add any subscribers. 

## What is the new behavior?
* By wrapping the notifications in a `setTimeout(() => ..., 0)`, we are able to push the `notifyAllSubscribers` function into the event loop and prioritise running `onAuthStateChange` first. 
## Additional context
* Because I couldn't reproduce the problem, I had to come up with scenarios which would simulate `onAuthStateChange` being run at a later time. 

1. Simulate a computationally intensive function before `onAuthStateChange` runs
```js
useEffect(() => {
    async function setUpCallbacks() {
      let start = Date.now(),
        now = start
      while (now - start < 1 * 1000) {
        now = Date.now()
      }
      auth.onAuthStateChange((_event, session) => {
        if (_event === 'PASSWORD_RECOVERY') {
          console.log(_event, session)
        }
      })
    }
    setUpCallbacks()
  }, [])
```
  * From this example, `setUpCallbacks()` is pushed into the event queue earlier than `notifyAllSubscribers` and `onAuthStateChange` manages to set up the callbacks first. 

2. Simulate an API call before `onAuthStateChange` runs
```js
useEffect(() => {
    async function setUpCallbacks() {
      // simulate an API call here
      await new Promise((r) => setTimeout(r, 0))
      auth.onAuthStateChange((_event, session) => {
        if (_event === 'PASSWORD_RECOVERY') {
          console.log(_event, session)
        }
      })
    }
    setUpCallbacks()
  }, [])
```
  * From this example, it was also observed that `onAuthStateChange` runs before `notifyAllSubscribers`.

3. Simulate an expensive API call / multiple API calls made before `onAuthStateChange` runs 

```js
useEffect(() => {
    async function setUpCallbacks() {
      // simulate an expensive API call here / multiple API calls being made 
      await new Promise((r) => setTimeout(r, 3000))
      auth.onAuthStateChange((_event, session) => {
        if (_event === 'PASSWORD_RECOVERY') {
          console.log(_event, session)
        }
      })
    }
    setUpCallbacks()
  }, [])
```
  * Unfortunately, `notifyAllSubscribers` runs before `onAuthStateChange` is able to mount the subscribers. This could be the scenario that some developers are running into since they might be running other API calls in the parent component which would delay the invocation of `onAuthStateChange`. It is recommended to call `onAuthStateChange` as early as possible (preferably right after the `GoTrueClient` has been instantiated) for now. 

