### PR TITLE
feat: dont fire `SIGNED_IN` event on `PASSWORD_RECOVERY`

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -220,9 +220,10 @@ export default class GoTrueClient {
         await this._saveSession(session)
 
         setTimeout(() => {
-          this._notifyAllSubscribers('SIGNED_IN', session)
           if (redirectType === 'recovery') {
             this._notifyAllSubscribers('PASSWORD_RECOVERY', session)
+          } else {
+            this._notifyAllSubscribers('SIGNED_IN', session)
           }
         }, 0)
 


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Only fire either the `PASSWORD_RECOVERY` event or the `SIGNED_IN` event instead of firing both when a password recovery link is clicked
* Mentioned in: https://github.com/supabase/gotrue-js/issues/349
