### PR TITLE
refactor: drop oauth_

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -400,7 +400,7 @@ export default class GoTrueClient {
     const { data, error } = await _request(
       this.fetch,
       'POST',
-      `${this.url}/token?grant_type=oauth_pkce`,
+      `${this.url}/token?grant_type=pkce`,
       {
         headers: this.headers,
         body: {


### PR DESCRIPTION
change `oauth_pkce` to be just `pkce` so that  magic link, recovery, etc can make use of the same route

Upd: realized that there's still a need to encode what kind of flow resulted in the token in order for `issueRefreshToken` to track where the token came from