### PR TITLE
Replacing `crypto-js` with the native `ohash`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "cross-fetch": "^3.1.5"
+        "cross-fetch": "^3.1.5",
+        "ohash": "^1.0.0"
       },
       "devDependencies": {
         "@types/faker": "^5.1.6",
@@ -5449,6 +5450,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/ohash": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ohash/-/ohash-1.0.0.tgz",
+      "integrity": "sha512-kxSyzq6tt+6EE/xCnD1XaFhCCjUNUaz3X30rJp6mnjGLXAAvuPFqohMdv0aScWzajR45C29HyBaXZ8jXBwnh9A=="
     },
     "node_modules/on-finished": {
       "version": "2.4.1",
@@ -11127,6 +11133,11 @@
         "define-properties": "^1.1.3",
         "es-abstract": "^1.19.1"
       }
+    },
+    "ohash": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ohash/-/ohash-1.0.0.tgz",
+      "integrity": "sha512-kxSyzq6tt+6EE/xCnD1XaFhCCjUNUaz3X30rJp6mnjGLXAAvuPFqohMdv0aScWzajR45C29HyBaXZ8jXBwnh9A=="
     },
     "on-finished": {
       "version": "2.4.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,9 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "cross-fetch": "^3.1.5",
-        "crypto-js": "^4.1.1"
+        "cross-fetch": "^3.1.5"
       },
       "devDependencies": {
-        "@types/crypto-js": "^4.1.1",
         "@types/faker": "^5.1.6",
         "@types/jest": "^28.1.6",
         "@types/jsonwebtoken": "^8.5.6",
@@ -1250,12 +1248,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/crypto-js": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@types/crypto-js/-/crypto-js-4.1.1.tgz",
-      "integrity": "sha512-BG7fQKZ689HIoc5h+6D2Dgq1fABRa0RbBWKBd9SP/MVRVXROflpm5fhwyATX5duFmbStzyzyycPB8qUYKDH3NA==",
-      "dev": true
-    },
     "node_modules/@types/express": {
       "version": "4.17.13",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
@@ -2306,11 +2298,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/crypto-js": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz",
-      "integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw=="
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -7968,12 +7955,6 @@
         "@types/node": "*"
       }
     },
-    "@types/crypto-js": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@types/crypto-js/-/crypto-js-4.1.1.tgz",
-      "integrity": "sha512-BG7fQKZ689HIoc5h+6D2Dgq1fABRa0RbBWKBd9SP/MVRVXROflpm5fhwyATX5duFmbStzyzyycPB8qUYKDH3NA==",
-      "dev": true
-    },
     "@types/express": {
       "version": "4.17.13",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
@@ -8769,11 +8750,6 @@
         "shebang-command": "^2.0.0",
         "which": "^2.0.1"
       }
-    },
-    "crypto-js": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz",
-      "integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw=="
     },
     "debug": {
       "version": "4.3.4",

--- a/package.json
+++ b/package.json
@@ -36,11 +36,9 @@
     "docs:json": "typedoc --json docs/v2/spec.json --excludeExternals --excludePrivate --excludeProtected src/index.ts"
   },
   "dependencies": {
-    "cross-fetch": "^3.1.5",
-    "crypto-js": "^4.1.1"
+    "cross-fetch": "^3.1.5"
   },
   "devDependencies": {
-    "@types/crypto-js": "^4.1.1",
     "@types/faker": "^5.1.6",
     "@types/jest": "^28.1.6",
     "@types/jsonwebtoken": "^8.5.6",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "docs:json": "typedoc --json docs/v2/spec.json --excludeExternals --excludePrivate --excludeProtected src/index.ts"
   },
   "dependencies": {
-    "cross-fetch": "^3.1.5"
+    "cross-fetch": "^3.1.5",
+    "ohash": "^1.0.0"
   },
   "devDependencies": {
     "@types/faker": "^5.1.6",

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -1,5 +1,5 @@
 import { SupportedStorage } from './types'
-import nodeCrypto from 'node:crypto'
+import { sha256 as sha256Ohash } from 'ohash'
 export function expiresAt(expiresIn: number) {
   const timeNow = Math.round(Date.now() / 1000)
   return timeNow + expiresIn
@@ -259,7 +259,7 @@ async function sha256(randomString: string) {
   const encoder = new TextEncoder()
   const encodedData = encoder.encode(randomString)
   if (!isBrowser()) {
-    return nodeCrypto.createHash('sha256').update(randomString).digest('hex')
+	return sha256Ohash(randomString).toString()
   }
   const hash = await window.crypto.subtle.digest('SHA-256', encodedData)
   const bytes = new Uint8Array(hash)

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -1,5 +1,5 @@
 import { SupportedStorage } from './types'
-import sha256CryptoJS from 'crypto-js/sha256'
+import nodeCrypto from 'node:crypto'
 export function expiresAt(expiresIn: number) {
   const timeNow = Math.round(Date.now() / 1000)
   return timeNow + expiresIn
@@ -259,7 +259,7 @@ async function sha256(randomString: string) {
   const encoder = new TextEncoder()
   const encodedData = encoder.encode(randomString)
   if (!isBrowser()) {
-    return sha256CryptoJS(randomString).toString()
+    return nodeCrypto.createHash('sha256').update(randomString).digest('hex')
   }
   const hash = await window.crypto.subtle.digest('SHA-256', encodedData)
   const bytes = new Uint8Array(hash)


### PR DESCRIPTION
## What kind of change does this PR introduce?
This PR solves the bug below when running with `nuxt` and `supabase`. 

```
Uncaught SyntaxError: The requested module '/_nuxt/node_modules/crypto-js/sha256.js?v=a4564608' does not provide an export named 'default'
```

As shown in [this discussion](https://github.com/orgs/supabase/discussions/13340)

## What is the current behavior?

The bug completely breaks the use of `supabase` in the latest version with nuxt.

## What is the new behavior?

Everything works :-)

