### PR TITLE
fix: add email as a verification type

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -498,7 +498,7 @@ export interface VerifyEmailOtpParams {
 }
 
 export type MobileOtpType = 'sms' | 'phone_change'
-export type EmailOtpType = 'signup' | 'invite' | 'magiclink' | 'recovery' | 'email_change'
+export type EmailOtpType = 'signup' | 'invite' | 'magiclink' | 'recovery' | 'email_change' | 'email'
 
 export type SignInWithSSO = {
   options?: {


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Update the types to include `email` as a verification type
* Related gotrue PR: https://github.com/supabase/gotrue/pull/885 