### PR TITLE
feat: increase auto refresh tick duration to 30s from 10s

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -81,7 +81,7 @@ const DEFAULT_OPTIONS: Omit<Required<GoTrueClientOptions>, 'fetch' | 'storage'> 
 }
 
 /** Current session will be checked for refresh at this interval. */
-const AUTO_REFRESH_TICK_DURATION = 10 * 1000
+const AUTO_REFRESH_TICK_DURATION = 30 * 1000
 
 /**
  * A token refresh will be attempted this many ticks before the current session expires. */


### PR DESCRIPTION
It appears that for unknown reasons the `/token` endpoint in GoTrue may last significantly longer than 10 seconds. This would mean that a repeat request could be sent out while the first one has not finished.

Longer request times than 30 seconds are generally not possible on the modern web, as many CDNs and proxies default time-out responses to 30 seconds.