### PR TITLE
feat: revert use `Deno.unrefTimer` to stop runtime from hanging

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -1281,10 +1281,6 @@ export default class GoTrueClient {
       // finished and tests run endlessly. This can be prevented by calling
       // `unref()` on the returned object.
       ticker.unref()
-    } else if (typeof Deno !== undefined && typeof Deno.unrefTimer === 'function') {
-      // similar like for NodeJS, but with the Deno API
-      // https://deno.land/api@latest?unstable&s=Deno.unrefTimer
-      Deno.unrefTimer(ticker)
     }
 
     // run the tick immediately


### PR DESCRIPTION
Reverts supabase/gotrue-js#632