### PR TITLE
feat: drop window prefix

### DIFF
--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -244,24 +244,24 @@ function dec2hex(dec: number) {
 export function generatePKCEVerifier() {
   const verifierLength = 56
   const array = new Uint32Array(verifierLength)
-  if (typeof window.crypto === 'undefined') {
+  if (typeof crypto === 'undefined') {
     throw new Error(
       'PKCE is not supported on devices without WebCrypto API support, please add polyfills'
     )
   }
-  window.crypto.getRandomValues(array)
+  crypto.getRandomValues(array)
   return Array.from(array, dec2hex).join('')
 }
 
 async function sha256(randomString: string) {
   const encoder = new TextEncoder()
   const encodedData = encoder.encode(randomString)
-  if (typeof window.crypto === 'undefined') {
+  if (typeof crypto === 'undefined') {
     throw new Error(
       'PKCE is not supported on devices without WebCrypto API support, please add polyfills'
     )
   }
-  const hash = await window.crypto.subtle.digest('SHA-256', encodedData)
+  const hash = await crypto.subtle.digest('SHA-256', encodedData)
   const bytes = new Uint8Array(hash)
 
   return Array.from(bytes)


### PR DESCRIPTION
We drop the window prefix so that crypto can also draw from `globalThis` when in a node js environment