### PR TITLE
fix: signOut should remove any unused code verifier

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -976,6 +976,7 @@ export default class GoTrueClient {
       }
     }
     await this._removeSession()
+    await removeItemAsync(this.storage, `${this.storageKey}-code-verifier`)
     this._notifyAllSubscribers('SIGNED_OUT', null)
     return { error: null }
   }
@@ -1273,7 +1274,6 @@ export default class GoTrueClient {
     const ticker = setInterval(() => this._autoRefreshTokenTick(), AUTO_REFRESH_TICK_DURATION)
     this.autoRefreshTicker = ticker
 
-
     if (ticker && typeof ticker === 'object' && typeof ticker.unref === 'function') {
       // ticker is a NodeJS Timeout object that has an `unref` method
       // https://nodejs.org/api/timers.html#timeoutunref
@@ -1282,8 +1282,8 @@ export default class GoTrueClient {
       // finished and tests run endlessly. This can be prevented by calling
       // `unref()` on the returned object.
       ticker.unref()
-    // @ts-ignore
-    } else if (typeof Deno !== "undefined" && typeof Deno.unrefTimer === 'function') {
+      // @ts-ignore
+    } else if (typeof Deno !== 'undefined' && typeof Deno.unrefTimer === 'function') {
       // similar like for NodeJS, but with the Deno API
       // https://deno.land/api@latest?unstable&s=Deno.unrefTimer
       // @ts-ignore


### PR DESCRIPTION
## What kind of change does this PR introduce?
* `signOut` method should remove any unused code verifier from local storage