### PR TITLE
feat: add support for sign in using refresh token

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -41,6 +41,7 @@ import type {
   Provider,
   Session,
   SignInWithIdTokenCredentials,
+  SignInWithRefreshTokenCredentials,
   SignInWithOAuthCredentials,
   SignInWithPasswordCredentials,
   SignInWithPasswordlessCredentials,
@@ -402,6 +403,24 @@ export default class GoTrueClient {
       queryParams: credentials.options?.queryParams,
       skipBrowserRedirect: credentials.options?.skipBrowserRedirect,
     })
+  }
+
+  /**
+   * Log in a user with a refresh_token.
+   */
+  async signInWithRefreshToken(credentials: SignInWithRefreshTokenCredentials): Promise<AuthResponse> {
+    try {
+      await this._removeSession()
+      const { refreshToken } = credentials
+      const { session, error } = await this._callRefreshToken(refreshToken)
+      if (error || !session) return { data: { user: null, session: null }, error }
+      return { data: { user: session.user, session }, error: null }
+    } catch (error) {
+      if (isAuthError(error)) {
+        return { data: { user: null, session: null }, error }
+      }
+      throw error
+    }
   }
 
   /**

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -467,6 +467,11 @@ export type SignInWithIdTokenCredentials = {
   }
 }
 
+export type SignInWithRefreshTokenCredentials = {
+  /** The user's refresh token. */
+  refreshToken: string
+}
+
 export type VerifyOtpParams = VerifyMobileOtpParams | VerifyEmailOtpParams
 export interface VerifyMobileOtpParams {
   /** The user's phone number. */


### PR DESCRIPTION
## What kind of change does this PR introduce?

Adds support for signing in with refreshToken, like existed in supabase-js v1

## What is the current behavior?

A user can't sign in with a refreshToken, which can make OAuth simpler on react-native

## What is the new behavior?

A user can sign in using a refreshToken by calling signInWithRefreshToken
