### PR TITLE
docs: correct docstring on exchangeCodeForSession

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -405,7 +405,7 @@ export default class GoTrueClient {
   }
 
   /**
-   * Log in an existing user via a third-party provider.
+   * Log in an existing user by exchanging an Auth Code issued during the PKCE flow.
    */
   async exchangeCodeForSession(authCode: string): Promise<AuthResponse> {
     const codeVerifier = await getItemAsync(this.storage, `${this.storageKey}-code-verifier`)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Currently, the doc string states that it logs in a user via a third party provider. This is a relic from when it was only used for `signInWithOAuth`. The docstring has since been updated