### PR TITLE
Added missing zoom provider in types.ts

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -19,6 +19,7 @@ export type Provider =
   | 'twitch'
   | 'twitter'
   | 'workos'
+  | 'zoom'
 
 export type AuthChangeEventMFA = 'MFA_CHALLENGE_VERIFIED'
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix
## What is the current behavior?

Zoom is not mentioned among the other providers in /src/lib/types.ts file

Doc: https://supabase.com/docs/guides/auth/social-login/auth-zoom#add-login-code-to-your-client-app

## What is the new behavior?
`signInWithOAuth` doesn't throw type error

```
async function signInWithZoom() {
  const { data, error } = await supabase.auth.signInWithOAuth({
    provider: 'zoom',
  })
}
```

## Additional context

Issue:  https://github.com/supabase/gotrue-js/issues/675
