### PR TITLE
fix: only refresh the session if autoRefreshToken is enabled

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -715,12 +715,15 @@ export default class GoTrueClient {
       return { data: { session: currentSession }, error: null }
     }
 
-    const { session, error } = await this._callRefreshToken(currentSession.refresh_token)
-    if (error) {
-      return { data: { session: null }, error }
+    if (this.autoRefreshToken && currentSession.refresh_token) {
+      const { session, error } = await this._callRefreshToken(currentSession.refresh_token)
+      if (error) {
+        return { data: { session: null }, error }
+      }
+      return { data: { session }, error: null }
     }
 
-    return { data: { session }, error: null }
+    return { data: { session: null }, error: null }
   }
 
   /**
@@ -930,9 +933,9 @@ export default class GoTrueClient {
         const { data, error } = await this.exchangeCodeForSession(authCode)
         if (error) throw error
         if (!data.session) throw new AuthPKCEGrantCodeExchangeError('No session detected.')
-        let url = new URL(window.location.href);
+        let url = new URL(window.location.href)
         url.searchParams.delete('code')
-        window.history.replaceState(window.history.state, "", url.toString())
+        window.history.replaceState(window.history.state, '', url.toString())
         return { data: { session: data.session, redirectType: null }, error: null }
       }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Partially fixes #677 
* `getSession` should only refresh the session if `autoRefreshToken` is enabled
* Related: Just merged in https://github.com/supabase/gotrue-js/pull/598 which should fix the issue of `_recoverAndRefresh` removing the session from local storage if it's expired, thus preventing the developer from handling the session refresh on their own 

Note: This seems like a possible breaking change for all those who rely on `getSession` to always return a valid session even if the token has expired and regardless of whether `autoRefreshToken` is enabled. Should we return the expired session if `autoRefreshToken` is `false`? 

Edit: I think it will still be useful to return the expired session if `autoRefreshToken` is `false` so that the developer can use the refresh token to refresh the session with `refreshSession()`. I'm also thinking of adding a `isExpired` field to the `Session` object so that it's easier for the developer to check if the session is expired. 