### PR TITLE
fix: `signInWithOAuth` should accept an invite token

### DIFF
--- a/example/react/src/App.js
+++ b/example/react/src/App.js
@@ -20,6 +20,7 @@ function App() {
   let [password, setPassword] = useState('')
   let [otp, setOtp] = useState('')
   let [rememberMe, setRememberMe] = useState(false)
+  let [inviteToken, setInviteToken] = useState()
 
   useEffect(() => {
     async function session() {
@@ -50,10 +51,17 @@ function App() {
     }
   }, [])
 
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search)
+    const inviteToken = params.get('invite_token')
+    setInviteToken(inviteToken)
+  }, [])
+
   async function handleOAuthLogin(provider) {
     let { error } = await auth.signInWithOAuth({
       provider,
       options: {
+        inviteToken: inviteToken ?? null,
         redirectTo: 'http://localhost:3000/welcome',
       },
     })

--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -398,6 +398,7 @@ export default class GoTrueClient {
     await this._removeSession()
 
     return await this._handleProviderSignIn(credentials.provider, {
+      inviteToken: credentials.options?.inviteToken,
       redirectTo: credentials.options?.redirectTo,
       scopes: credentials.options?.scopes,
       queryParams: credentials.options?.queryParams,
@@ -930,9 +931,9 @@ export default class GoTrueClient {
         const { data, error } = await this.exchangeCodeForSession(authCode)
         if (error) throw error
         if (!data.session) throw new AuthPKCEGrantCodeExchangeError('No session detected.')
-        let url = new URL(window.location.href);
+        let url = new URL(window.location.href)
         url.searchParams.delete('code')
-        window.history.replaceState(window.history.state, "", url.toString())
+        window.history.replaceState(window.history.state, '', url.toString())
         return { data: { session: data.session, redirectType: null }, error: null }
       }
 
@@ -1171,6 +1172,7 @@ export default class GoTrueClient {
   private async _handleProviderSignIn(
     provider: Provider,
     options: {
+      inviteToken?: string
       redirectTo?: string
       scopes?: string
       queryParams?: { [key: string]: string }
@@ -1178,6 +1180,7 @@ export default class GoTrueClient {
     }
   ) {
     const url: string = await this._getUrlForProvider(provider, {
+      inviteToken: options.inviteToken,
       redirectTo: options.redirectTo,
       scopes: options.scopes,
       queryParams: options.queryParams,
@@ -1492,6 +1495,7 @@ export default class GoTrueClient {
   private async _getUrlForProvider(
     provider: Provider,
     options: {
+      inviteToken?: string
       redirectTo?: string
       scopes?: string
       queryParams?: { [key: string]: string }
@@ -1503,6 +1507,9 @@ export default class GoTrueClient {
     }
     if (options?.scopes) {
       urlParams.push(`scopes=${encodeURIComponent(options.scopes)}`)
+    }
+    if (options?.inviteToken) {
+      urlParams.push(`invite_token=${encodeURIComponent(options.inviteToken)}`)
     }
     if (this.flowType === 'pkce') {
       const codeVerifier = generatePKCEVerifier()

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -442,6 +442,8 @@ export type SignInWithOAuthCredentials = {
   /** One of the providers supported by GoTrue. */
   provider: Provider
   options?: {
+    /** An invite token sent to the user's email. */
+    inviteToken?: string
     /** A URL to send the user to after they are confirmed. */
     redirectTo?: string
     /** A space-separated list of scopes granted to the OAuth application. */


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Partially address #670 
* Improves the DX for accepting an invite through `signInWithOAuth` as mentioned in [this comment](https://github.com/supabase/gotrue-js/issues/670#issuecomment-1548968808)