### PR TITLE
fix: add reauthenticate method

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -257,6 +257,13 @@ export interface UserAttributes {
   password?: string
 
   /**
+   * The nonce sent for reauthentication if the user's password is to be updated.
+   *
+   * Call reauthenticate() to obtain the nonce first.
+   */
+  nonce?: string
+
+  /**
    * A custom data object to store the user's metadata. This maps to the `auth.users.user_metadata` column.
    *
    * The `data` should be a JSON object that includes user-specific info, such as their first and last name.


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Supercedes #258
* Adds `reauthenticate()` method to allow a user to request for a nonce to subsequently update their password
* Updates the type for `UserAttributes` which is used in `updateUser()` to include the `nonce` 
* If a nonce is not passed into `updateUser()`, an `AuthSessionMissingError()` will be returned

## Details
With this addition, the update password flow will look like the following when "Secure password change" is enabled on the Supabase dashboard. For users that are self-hosting gotrue and using gotrue-js, this requires setting the environmentr variable, `GOTRUE_SECURITY_UPDATE_PASSWORD_REQUIRE_REAUTHENTICATION="true"`
```

// Send reauthentication to the current user. User must be signed-in to perform this action.
await supabase.auth.reauthenticate()

// Update password 
await supabase.auth.updateUser({ password: "new-pasword", "nonce": "123456" }
```