### PR TITLE
refactor: update types for /token linked methods

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -315,17 +315,15 @@ export default class GoTrueClient {
 
       const { data, error } = res
 
-      if (error) {
+      if (error || !data) {
         return { data: { user: null, session: null }, error: error }
-      } else if (!data || !data.user) {
-        return { data: { user: null, session: null }, error: null }
       }
 
       const session: Session | null = data.session
-      const user: User = data.user
+      const user: User | null = data.user
 
-      if (session) {
-        await this._saveSession(session)
+      if (data.session) {
+        await this._saveSession(data.session)
         this._notifyAllSubscribers('SIGNED_IN', session)
       }
 
@@ -467,7 +465,11 @@ export default class GoTrueClient {
       })
 
       const { data, error } = res
-      if (error || !data) return { data: { user: null, session: null }, error }
+      if (error) {
+        return { data: { user: null, session: null }, error }
+      } else if (!data || !data.user || !data.session) {
+        return { data: { user: null, session: null }, error: null }
+      }
       if (data.session) {
         await this._saveSession(data.session)
         this._notifyAllSubscribers('SIGNED_IN', data.session)

--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -33,7 +33,7 @@ import { polyfillGlobalThis } from './lib/polyfills'
 import type {
   AuthChangeEvent,
   AuthResponse,
-  AuthSessionResponse,
+  AuthTokenResponse,
   CallRefreshTokenResult,
   GoTrueClientOptions,
   InitializeResult,
@@ -345,9 +345,7 @@ export default class GoTrueClient {
    * email/phone and password combination is wrong or that the account can only
    * be accessed via social login.
    */
-  async signInWithPassword(
-    credentials: SignInWithPasswordCredentials
-  ): Promise<AuthSessionResponse> {
+  async signInWithPassword(credentials: SignInWithPasswordCredentials): Promise<AuthTokenResponse> {
     try {
       await this._removeSession()
 
@@ -417,7 +415,7 @@ export default class GoTrueClient {
   /**
    * Log in an existing user by exchanging an Auth Code issued during the PKCE flow.
    */
-  async exchangeCodeForSession(authCode: string): Promise<AuthSessionResponse> {
+  async exchangeCodeForSession(authCode: string): Promise<AuthTokenResponse> {
     const codeVerifier = await getItemAsync(this.storage, `${this.storageKey}-code-verifier`)
     const { data, error } = await _request(
       this.fetch,
@@ -447,7 +445,7 @@ export default class GoTrueClient {
    *
    * @experimental
    */
-  async signInWithIdToken(credentials: SignInWithIdTokenCredentials): Promise<AuthSessionResponse> {
+  async signInWithIdToken(credentials: SignInWithIdTokenCredentials): Promise<AuthTokenResponse> {
     await this._removeSession()
 
     try {

--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -382,7 +382,7 @@ export default class GoTrueClient {
       if (error) {
         return { data: { user: null, session: null }, error }
       } else if (!data || !data.session) {
-        return { data: { user: null, session: null }, error: new AuthSessionMissingError() }
+        return { data: { user: null, session: null }, error: new AuthError('No session returned') }
       } else if (!data.user) {
         return { data: { user: null, session: null }, error: new AuthError('No user returned') }
       }
@@ -436,7 +436,7 @@ export default class GoTrueClient {
     if (error) {
       return { data: { user: null, session: null }, error }
     } else if (!data || !data.session) {
-      return { data: { user: null, session: null }, error: new AuthSessionMissingError() }
+      return { data: { user: null, session: null }, error: new AuthError('No session returned') }
     } else if (!data.user) {
       return { data: { user: null, session: null }, error: new AuthError('No user returned') }
     }

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -69,7 +69,11 @@ export class AuthSessionMissingError extends CustomAuthError {
   }
 }
 
-
+export class AuthInvalidTokenResponseError extends CustomAuthError {
+  constructor() {
+    super('Auth session or user missing', 'AuthInvalidTokenResponseError', 500)
+  }
+}
 
 export class AuthInvalidCredentialsError extends CustomAuthError {
   constructor(message: string) {

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -70,6 +70,7 @@ export class AuthSessionMissingError extends CustomAuthError {
 }
 
 
+
 export class AuthInvalidCredentialsError extends CustomAuthError {
   constructor(message: string) {
     super(message, 'AuthInvalidCredentialsError', 400)

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -69,6 +69,7 @@ export class AuthSessionMissingError extends CustomAuthError {
   }
 }
 
+
 export class AuthInvalidCredentialsError extends CustomAuthError {
   constructor(message: string) {
     super(message, 'AuthInvalidCredentialsError', 400)

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -69,6 +69,28 @@ export type AuthResponse =
       error: AuthError
     }
 
+export type AuthSessionResponse =
+  | {
+      data: {
+        user: User
+        session: Session
+      }
+      error: null
+    }
+  | {
+      data: {
+        user: null
+        session: null
+      }
+      error: AuthError
+    }
+  | {
+      data: {
+        user: null
+        session: null
+      }
+      error: null
+    }
 export type OAuthResponse =
   | {
       data: {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -69,7 +69,7 @@ export type AuthResponse =
       error: AuthError
     }
 
-export type AuthSessionResponse =
+export type AuthTokenResponse =
   | {
       data: {
         user: User

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -84,13 +84,7 @@ export type AuthTokenResponse =
       }
       error: AuthError
     }
-  | {
-      data: {
-        user: null
-        session: null
-      }
-      error: null
-    }
+
 export type OAuthResponse =
   | {
       data: {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Currently, the `AuthReponse` allows for the possibility of an [empty Session, empty User and no error](https://github.com/supabase/gotrue-js/blob/master/src/lib/types.ts#L56). This might not be ideal for users who might expect an error when no `User` or `Session` is returned.  This PR aims to eliminate this possibility via a more specific type which covers all token related endpoints.

We introduce a generic `AuthTokenResponse` to cover the case where there is no Session and no User but no error. In practice, this hopefully won't happen. Not too familiar with the typings so do feel free to lmk if there's anything I've missed or if there are alternative solutions.


Context: Aims to address #686. 