### PR TITLE
fix: verifyOtp should not removeSession for phone_change & email_change

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -546,7 +546,10 @@ export default class GoTrueClient {
    */
   async verifyOtp(params: VerifyOtpParams): Promise<AuthResponse> {
     try {
-      await this._removeSession()
+      if (params.type !== 'email_change' && params.type !== 'phone_change') {
+        // we don't want to remove the authenticated session if the user is performing an email_change or phone_change verification
+        await this._removeSession()
+      }
       const { data, error } = await _request(this.fetch, 'POST', `${this.url}/verify`, {
         headers: this.headers,
         body: {


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Fixes #696 where a user is signed out if they enter the wrong OTP for an `email_change` or `phone_change` verification