### PR TITLE
fix: added package name prefix to all `console.` methods in `src/`

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -174,7 +174,7 @@ export default class GoTrueClient {
 
     if (this.persistSession && this.storage === localStorageAdapter && !supportsLocalStorage()) {
       console.warn(
-        `No storage option exists to persist the session, which may result in unexpected behavior when using auth.
+        `[@supabase/gotrue-js] No storage option exists to persist the session, which may result in unexpected behavior when using auth.
         If you want to set persistSession to true, please provide a storage option or you may set persistSession to false to disable this warning.`
       )
     }
@@ -184,7 +184,7 @@ export default class GoTrueClient {
         this.broadcastChannel = new globalThis.BroadcastChannel(this.storageKey)
       } catch (e: any) {
         console.error(
-          'Failed to create a new BroadcastChannel, multi-tab state changes will not be available',
+          '[@supabase/gotrue-js] Failed to create a new BroadcastChannel, multi-tab state changes will not be available',
           e
         )
       }
@@ -1112,7 +1112,7 @@ export default class GoTrueClient {
       this.stateChangeEmitters.get(id)?.callback('INITIAL_SESSION', session)
     } catch (err) {
       this.stateChangeEmitters.get(id)?.callback('INITIAL_SESSION', null)
-      console.error(err)
+      console.error('[@supabase/gotrue-js]', err)
     }
   }
 
@@ -1253,7 +1253,7 @@ export default class GoTrueClient {
           const { error } = await this._callRefreshToken(currentSession.refresh_token)
 
           if (error) {
-            console.log(error.message)
+            console.log('[@supabase/gotrue-js]', error.message)
             await this._removeSession()
           }
         }
@@ -1264,7 +1264,7 @@ export default class GoTrueClient {
         this._notifyAllSubscribers('SIGNED_IN', currentSession)
       }
     } catch (err) {
-      console.error(err)
+      console.error('[@supabase/gotrue-js]', err)
       return
     }
   }
@@ -1358,7 +1358,7 @@ export default class GoTrueClient {
         window.removeEventListener('visibilitychange', callback)
       }
     } catch (e) {
-      console.error('removing visibilitychange callback failed', e)
+      console.error('[@supabase/gotrue-js] removing visibilitychange callback failed', e)
     }
   }
 
@@ -1469,7 +1469,7 @@ export default class GoTrueClient {
         await this._callRefreshToken(session.refresh_token)
       }
     } catch (e: any) {
-      console.error('Auto refresh tick failed with error. This is likely a transient error.', e)
+      console.error('[@supabase/gotrue-js] Auto refresh tick failed with error. This is likely a transient error.', e)
     }
   }
 
@@ -1497,7 +1497,7 @@ export default class GoTrueClient {
       // current visbility state
       await this._onVisibilityChanged(true) // initial call
     } catch (error) {
-      console.error('_handleVisibilityChange', error)
+      console.error('[@supabase/gotrue-js] _handleVisibilityChange', error)
     }
   }
 

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -275,7 +275,7 @@ function base64urlencode(str: string) {
 export async function generatePKCEChallenge(verifier: string) {
   if (typeof crypto === 'undefined') {
     console.warn(
-      'WebCrypto API is not supported. Code challenge method will default to use plain instead of sha256.'
+      '[@supabase/gotrue-js] WebCrypto API is not supported. Code challenge method will default to use plain instead of sha256.'
     )
     return verifier
   }


### PR DESCRIPTION
## What kind of change does this PR introduce?

After upgrading @supabase/supabase-js, I stumbled on an error message (`No storage option exists to persist the session, which may result in unexpected behavior when using auth.
        If you want to set persistSession to true, please provide a storage option or you may set persistSession to false to disable this warning.`).

It took me a while to figure out from which package this comes and why. Found it only because it was reported in the nuxt/supabase repo https://github.com/nuxt-modules/supabase/issues/188.

I therefore suggest to prefix console.error / console.warning with this package's name, so you can easily check where this random error in your console comes from.

## What is the current behavior?

Errors are logged into the server console without me having an idea from which package they come from.

## What is the new behavior?

Now every error/warning has the package name `[@supabase/gotrue-js]` prefixed.
