### PR TITLE
feat: `_recoverAndRefresh` does not remove session on retryable error

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -11,6 +11,7 @@ import {
   AuthUnknownError,
   isAuthApiError,
   isAuthError,
+  isAuthRetryableFetchError,
 } from './lib/errors'
 import { Fetch, _request, _sessionResponse, _userResponse, _ssoResponse } from './lib/fetch'
 import {
@@ -1274,8 +1275,11 @@ export default class GoTrueClient {
           const { error } = await this._callRefreshToken(currentSession.refresh_token)
 
           if (error) {
-            console.log(error.message)
-            await this._removeSession()
+            console.error(error)
+
+            if (!isAuthRetryableFetchError(error)) {
+              await this._removeSession()
+            }
           }
         }
       } else {

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -120,3 +120,7 @@ export class AuthRetryableFetchError extends CustomAuthError {
     super(message, 'AuthRetryableFetchError', status)
   }
 }
+
+export function isAuthRetryableFetchError(error: unknown): error is AuthRetryableFetchError {
+  return isAuthError(error) && error.name === 'AuthRetryableFetchError'
+}


### PR DESCRIPTION
If the `_callRefreshToken` method failed with a network error, the session would have been removed, which should generally not be the case as the device is offline.