### PR TITLE
feat: no persist of session with no changes in `_recoverAndRefresh`

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -1283,9 +1283,9 @@ export default class GoTrueClient {
           }
         }
       } else {
-        if (this.persistSession) {
-          await this._saveSession(currentSession)
-        }
+        // no need to persist currentSession again, as we just loaded it from
+        // local storage; persisting it again may overwrite a value saved by
+        // another lient with access to the same local storage
         await this._notifyAllSubscribers('SIGNED_IN', currentSession)
       }
     } catch (err) {

--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -1285,7 +1285,7 @@ export default class GoTrueClient {
       } else {
         // no need to persist currentSession again, as we just loaded it from
         // local storage; persisting it again may overwrite a value saved by
-        // another lient with access to the same local storage
+        // another client with access to the same local storage
         await this._notifyAllSubscribers('SIGNED_IN', currentSession)
       }
     } catch (err) {


### PR DESCRIPTION
In `_recoverAndRefresh()` if the session was valid and not expired by the margin, it was loading and then persisting which could have overridden a new session value saved by another tab in local storage.

This explains some errors where a refresh token is used again after a long time.