### PR TITLE
fix: don't remove session in resend

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -723,7 +723,11 @@ export default class GoTrueClient {
    */
   async resend(credentials: ResendParams): Promise<AuthOtpResponse> {
     try {
-      await this._removeSession()
+
+      if (credentials.type != "email_change" && credentials.type != "phone_change") {
+        await this._removeSession();
+      }
+      
       const endpoint = `${this.url}/resend`
       if ('email' in credentials) {
         const { email, type, options } = credentials


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When you call the `resend` method to e.g. resend an email to change your email, you get logged out.

## What is the new behavior?

On email and phone change you don't get logged out.

## Additional context

I noticed this when implementing this method in gotrue-dart https://github.com/supabase/supabase-flutter/pull/517#discussion_r1246427921
