### PR TITLE
fix: redirect URL option for resend of confirmation emails

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -729,6 +729,7 @@ export default class GoTrueClient {
         const { email, type, options } = credentials
         const { error } = await _request(this.fetch, 'POST', endpoint, {
           headers: this.headers,
+          redirectTo: options?.redirectTo,
           body: {
             email,
             type,

--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -721,12 +721,12 @@ export default class GoTrueClient {
   /**
    * Resends an existing signup confirmation email, email change email, SMS OTP or phone change OTP.
    */
-  async resend(credentials: ResendParams): Promise<AuthOtpResponse> {
+  async resend(params: ResendParams): Promise<AuthOtpResponse> {
     try {
       await this._removeSession()
       const endpoint = `${this.url}/resend`
-      if ('email' in credentials) {
-        const { email, type, options } = credentials
+      if ('email' in params) {
+        const { email, type, options } = params
         const { error } = await _request(this.fetch, 'POST', endpoint, {
           headers: this.headers,
           redirectTo: options?.redirectTo,
@@ -737,8 +737,8 @@ export default class GoTrueClient {
           },
         })
         return { data: { user: null, session: null }, error }
-      } else if ('phone' in credentials) {
-        const { phone, type, options } = credentials
+      } else if ('phone' in params) {
+        const { phone, type, options } = params
         const { data, error } = await _request(this.fetch, 'POST', endpoint, {
           headers: this.headers,
           body: {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -551,6 +551,8 @@ export type ResendParams =
       type: Extract<EmailOtpType, 'signup' | 'email_change'>
       email: string
       options?: {
+        /** The redirect url embedded in the email link */
+        redirectTo?: string
         /** Verification token received when the user completes the captcha on the site. */
         captchaToken?: string
       }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix: add option to specify the redirect URL when using `supabase.auth.resend()`.

## What is the current behavior?

Was currently not possible, related issue: #718  

## What is the new behavior?

It is now possible to specify the redirect URL:
```ts
supabase.auth.resend({
  type: 'signup',
  email: '<email>',
  options: {
    redirectTo: '<URL>',
  }
});
```

## Additional context

The backend (GoTrue) already supported specifying the redirect URL for the link in the signup/change_email mail.
