### PR TITLE
feat: Add 'kakao' to Provider type

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -11,6 +11,7 @@ export type Provider =
   | 'github'
   | 'gitlab'
   | 'google'
+  | 'kakao'
   | 'keycloak'
   | 'linkedin'
   | 'notion'


### PR DESCRIPTION
## What kind of change does this PR introduce?
This PR adds 'kakao' to `Provider` type.
Kakao provider was recently added to `supabase/gotrue` through this [PR](https://github.com/supabase/gotrue/pull/834)(document has also been updated. [PR](https://github.com/supabase/supabase/pull/14287)) 
## What is the current behavior?
IDE warns type error because there is no 'kakao' in `Provider` type.
![image](https://github.com/supabase/gotrue-js/assets/27193396/af8a4071-fc1e-4a3f-b019-3f92e49212dc)


## What is the new behavior?
'kakao' added properly in `Provider` type, so no error shown in IDE

## Additional context
Please let me know if I have to change anything to be approved. Thank you!
