### PR TITLE
fix: add verify token hash

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -623,13 +623,20 @@ export default class GoTrueClient {
         // we don't want to remove the authenticated session if the user is performing an email_change or phone_change verification
         await this._removeSession()
       }
+
+      let redirectTo = undefined
+      let captchaToken = undefined
+      if ('options' in params) {
+        redirectTo = params.options?.redirectTo
+        captchaToken = params.options?.captchaToken
+      }
       const { data, error } = await _request(this.fetch, 'POST', `${this.url}/verify`, {
         headers: this.headers,
         body: {
           ...params,
-          gotrue_meta_security: { captcha_token: params.options?.captchaToken },
+          gotrue_meta_security: { captcha_token: captchaToken },
         },
-        redirectTo: params.options?.redirectTo,
+        redirectTo,
         xform: _sessionResponse,
       })
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -509,7 +509,7 @@ export type SignInWithIdTokenCredentials = {
   }
 }
 
-export type VerifyOtpParams = VerifyMobileOtpParams | VerifyEmailOtpParams
+export type VerifyOtpParams = VerifyMobileOtpParams | VerifyEmailOtpParams | VerifyTokenHashParams
 export interface VerifyMobileOtpParams {
   /** The user's phone number. */
   phone: string
@@ -539,9 +539,21 @@ export interface VerifyEmailOtpParams {
   options?: {
     /** A URL to send the user to after they are confirmed. */
     redirectTo?: string
-    /** Verification token received when the user completes the captcha on the site. */
+
+    /** Verification token received when the user completes the captcha on the site.
+     *
+     * @deprecated
+     */
     captchaToken?: string
   }
+}
+
+export interface VerifyTokenHashParams {
+  /** The token hash used in an email link */
+  token_hash: string
+
+  /** The user's verification type. */
+  type: EmailOtpType
 }
 
 export type MobileOtpType = 'sms' | 'phone_change'


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Allows passing a `token_hash` and `type` in `verifyOtp` method 
* Supports this change on gotrue: https://github.com/supabase/gotrue/pull/1165
* Fixes #694