### PR TITLE
fix: add emailRedirectTo option to resend method

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -735,6 +735,7 @@ export default class GoTrueClient {
             type,
             gotrue_meta_security: { captcha_token: options?.captchaToken },
           },
+          redirectTo: options?.emailRedirectTo,
         })
         return { data: { user: null, session: null }, error }
       } else if ('phone' in credentials) {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -552,6 +552,8 @@ export type ResendParams =
       type: Extract<EmailOtpType, 'signup' | 'email_change'>
       email: string
       options?: {
+        /** A URL to send the user to after they have signed-in. */
+        emailRedirectTo?: string
         /** Verification token received when the user completes the captcha on the site. */
         captchaToken?: string
       }


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Adds the `emailRedirectTo` option to resend method
* Resolves https://github.com/supabase/gotrue/issues/1142