### PR TITLE
feat: bump typescript target to ES2017

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     "outDir": "dist/main",
     "rootDir": "src",
     "sourceMap": true,
-    "target": "ES2015",
+    "target": "ES2017",
 
     "strict": true,
 


### PR DESCRIPTION
Sets the TypeScript compile target to ES2017 as ES2015 is now 8 years old. Furthermore, ES2017 targets do not transpile async/await to JS generators, which means that stack traces will now be readable.