### PR TITLE
feat: parse `expires_at` if present

### DIFF
--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -143,8 +143,12 @@ export function _sessionResponse(data: any): AuthResponse {
   let session = null
   if (hasSession(data)) {
     session = { ...data }
-    session.expires_at = expiresAt(data.expires_in)
+
+    if (!data.expires_at) {
+      session.expires_at = expiresAt(data.expires_in)
+    }
   }
+
   const user: User = data.user ?? (data as User)
   return { data: { session, user }, error: null }
 }

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -93,7 +93,8 @@ export const resolveFetch = (customFetch?: Fetch): Fetch => {
   if (customFetch) {
     _fetch = customFetch
   } else if (typeof fetch === 'undefined') {
-    _fetch = (...args) => import('@supabase/node-fetch' as any).then(({ default: fetch }) => fetch(...args))
+    _fetch = (...args) =>
+      import('@supabase/node-fetch' as any).then(({ default: fetch }) => fetch(...args))
   } else {
     _fetch = fetch
   }


### PR DESCRIPTION
Related to: https://github.com/supabase/gotrue/pull/1183

Built on top of: #733 

Parses `expires_at` from the URL or request if present. Emits warnings if clock skew issues are detected.