### PR TITLE
Feat: client side error for larger passwords

### DIFF
--- a/src/GoTrueAdminApi.ts
+++ b/src/GoTrueAdminApi.ts
@@ -119,9 +119,6 @@ export default class GoTrueAdminApi {
     try {
       const { options, ...rest } = params
       const body: any = { ...rest, ...options }
-      if (options?.password && options.password.length > 72) {
-        throw new Error('Passwords larger than 72 chars are not supported')
-      }
       if ('newEmail' in rest) {
         // replace newEmail with new_email in request body
         body.new_email = rest?.newEmail
@@ -247,6 +244,9 @@ export default class GoTrueAdminApi {
    */
   async updateUserById(uid: string, attributes: AdminUserAttributes): Promise<UserResponse> {
     try {
+      if (attributes.password && attributes.password.length > 72) {
+        throw new Error('Passwords larger than 72 chars are not supported')
+      }
       return await _request(this.fetch, 'PUT', `${this.url}/admin/users/${uid}`, {
         body: attributes,
         headers: this.headers,

--- a/src/GoTrueAdminApi.ts
+++ b/src/GoTrueAdminApi.ts
@@ -119,6 +119,9 @@ export default class GoTrueAdminApi {
     try {
       const { options, ...rest } = params
       const body: any = { ...rest, ...options }
+      if (options?.password && options.password.length > 72) {
+        throw new Error('Passwords larger than 72 chars are not supported')
+      }
       if ('newEmail' in rest) {
         // replace newEmail with new_email in request body
         body.new_email = rest?.newEmail
@@ -151,6 +154,9 @@ export default class GoTrueAdminApi {
    */
   async createUser(attributes: AdminUserAttributes): Promise<UserResponse> {
     try {
+      if (attributes.password && attributes.password.length > 72) {
+        throw new Error('Passwords larger than 72 chars are not supported')
+      }
       return await _request(this.fetch, 'POST', `${this.url}/admin/users`, {
         body: attributes,
         headers: this.headers,
@@ -160,7 +166,6 @@ export default class GoTrueAdminApi {
       if (isAuthError(error)) {
         return { data: { user: null }, error }
       }
-
       throw error
     }
   }

--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -331,6 +331,11 @@ export default class GoTrueClient {
       let res: AuthResponse
       if ('email' in credentials) {
         const { email, password, options } = credentials
+        if (password.length > 72) {
+          throw new AuthInvalidCredentialsError(
+            'Passwords larger than 72 chars are not supported'
+          )
+        }
         let codeChallenge: string | null = null
         let codeChallengeMethod: string | null = null
         if (this.flowType === 'pkce') {
@@ -354,6 +359,11 @@ export default class GoTrueClient {
         })
       } else if ('phone' in credentials) {
         const { phone, password, options } = credentials
+        if (password.length > 72) {
+          throw new AuthInvalidCredentialsError(
+            'Passwords larger than 72 chars are not supported'
+          )
+        }
         res = await _request(this.fetch, 'POST', `${this.url}/signup`, {
           headers: this.headers,
           body: {
@@ -410,6 +420,11 @@ export default class GoTrueClient {
       let res: AuthResponse
       if ('email' in credentials) {
         const { email, password, options } = credentials
+        if (password.length > 72) {
+          throw new AuthInvalidCredentialsError(
+            'Passwords larger than 72 chars are not supported'
+          )
+        }
         res = await _request(this.fetch, 'POST', `${this.url}/token?grant_type=password`, {
           headers: this.headers,
           body: {
@@ -421,6 +436,11 @@ export default class GoTrueClient {
         })
       } else if ('phone' in credentials) {
         const { phone, password, options } = credentials
+        if (password.length > 72) {
+          throw new AuthInvalidCredentialsError(
+            'Passwords larger than 72 chars are not supported'
+          )
+        }
         res = await _request(this.fetch, 'POST', `${this.url}/token?grant_type=password`, {
           headers: this.headers,
           body: {

--- a/test/GoTrueClient.test.ts
+++ b/test/GoTrueClient.test.ts
@@ -826,6 +826,22 @@ describe('The auth client can signin with third-party oAuth providers', () => {
     })
   })
 
+  describe('Sign Up Enabled', () => {
+    test('User tries to sign up with password larger than 72 chars', async () => {
+      const { email, password } = mockUserCredentials()
+      const longPassword = 'a'.repeat(73)
+  
+      const signUpPromise = signUpEnabledClient.signUp({
+        email,
+        password: longPassword,
+      })
+  
+      await expect(signUpPromise).rejects.toThrow(
+        'Passwords larger than 72 chars are not supported'
+      )
+    })
+  })
+
   describe('Sign Up Disabled', () => {
     test('User cannot sign up', async () => {
       const { email, password } = mockUserCredentials()

--- a/test/GoTrueClient.test.ts
+++ b/test/GoTrueClient.test.ts
@@ -830,15 +830,13 @@ describe('The auth client can signin with third-party oAuth providers', () => {
     test('User tries to sign up with password larger than 72 chars', async () => {
       const { email, password } = mockUserCredentials()
       const longPassword = 'a'.repeat(73)
-  
       const signUpPromise = signUpEnabledClient.signUp({
         email,
         password: longPassword,
       })
-  
-      await expect(signUpPromise).rejects.toThrow(
-        'Passwords larger than 72 chars are not supported'
-      )
+      const result = await signUpPromise
+      expect(result.error).toBeInstanceOf(AuthError)
+      expect(result?.error?.message).toEqual('Passwords larger than 72 chars are not supported')
     })
   })
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Throws a client-side error when a password larger than 72 chars is attempted.
Documenting:
https://github.com/supabase/gotrue/issues/1101

## What is the current behavior?

Right now the password is truncated without any explicit indication that this happens to the user

## What is the new behavior?

It throws an error, so it is clear that passwords should be limited to 72 chars to avoid mistakes. 

## Additional context

Add any other context or screenshots.
