### PR TITLE
Improved typing of provider fields

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -231,7 +231,7 @@ export interface UserIdentity {
   identity_data?: {
     [key: string]: any
   }
-  provider: string
+  provider: Provider
   created_at?: string
   last_sign_in_at?: string
   updated_at?: string
@@ -265,7 +265,7 @@ export interface Factor {
 }
 
 export interface UserAppMetadata {
-  provider?: string
+  provider?: Provider
   [key: string]: any
 }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?
This changes the type of the `provider` fields on `UserAppMetadata` and `UserIdentity` from `string` to `Provider`, which is the more accurate type.

## What is the current behavior?
Right now, the field is typed as `string`, which tells typescript it can be any string, when in fact it can only ever be one of the values of `Provider`.

this is my first PR here, let me know of there's something I missed!