### PR TITLE
fix: localStorage not allowed error

### DIFF
--- a/src/lib/locks.ts
+++ b/src/lib/locks.ts
@@ -1,3 +1,5 @@
+import { supportsLocalStorage } from "./helpers";
+
 /**
  * @experimental
  */
@@ -7,7 +9,7 @@ export const internals = {
    */
   debug: !!(
     globalThis &&
-    globalThis.localStorage &&
+    supportsLocalStorage() &&
     globalThis.localStorage.getItem('supabase.gotrue-js.locks.debug') === 'true'
   ),
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

If localStorage is not allowed, e.g. `inside 'data:' URLs.`, an error occurs and it does not work correctly.

## What is the new behavior?

Use `supportsLocalStorage` to check if localStorage is available.

## Additional context

error

![スクリーンショット 2023-08-01 20 11 44](https://github.com/supabase/gotrue-js/assets/21324532/eb49a966-950d-4acf-8969-2dfda17ae81f)
