### PR TITLE
Add Beyond Identity passwordless (passkey) Auth Provider

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -5,6 +5,7 @@ import { Fetch } from './fetch'
 export type Provider =
   | 'apple'
   | 'azure'
+  | 'beyondidentity'
   | 'bitbucket'
   | 'discord'
   | 'facebook'


### PR DESCRIPTION
## What kind of change does this PR introduce?

This adds a new Auth Provider, Beyond Identity, with first class passkey support.
- supports: https://github.com/orgs/supabase/discussions/8677

## What is the current behavior?

No support for Beyond Identity OAuth

## What is the new behavior?

Support for Beyond Identity using OAuth

## Related PRs
