### PR TITLE
feat: add experimental `setLock` method

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -232,6 +232,20 @@ export default class GoTrueClient {
     this.initialize()
   }
 
+  /**
+   * Use this to dynamically set or change the lock function of the client. This API will break and may not exist in future versions. Use at your own risk.
+   * @experimental
+   */
+  setLock(lock: LockFn | null) {
+    if (lock) {
+      this.lock = lock
+    } else {
+      this.lock = lockNoOp
+    }
+
+    this._debug('#setLock', 'changed lock function', this.lock)
+  }
+
   private _debug(...args: any[]): GoTrueClient {
     if (this.logDebugMessages) {
       console.log(


### PR DESCRIPTION
Adds an API that can be used to dynamically set the locking function on the `GoTrueClient`. This is useful for testing out various locks on supabase.com/dashboard using feature flags.