### PR TITLE
fix: better defined localStorage support for debug

### DIFF
--- a/src/lib/locks.ts
+++ b/src/lib/locks.ts
@@ -1,3 +1,5 @@
+import { supportsLocalStorage } from "./helpers"
+
 /**
  * @experimental
  */
@@ -7,6 +9,7 @@ export const internals = {
    */
   debug: !!(
     globalThis &&
+    supportsLocalStorage() &&
     globalThis.localStorage &&
     globalThis.localStorage.getItem('supabase.gotrue-js.locks.debug') === 'true'
   ),


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

If using Supabase auth in a Deno application, running a `deno compile`'d executable would not be possible as the `internals.debug` property was still trying to access localStorage [which Deno can't do with an executable](https://deno.land/manual@v1.36.0/tools/compiler#unavailable-in-executables)

Fixes #752

## What is the new behavior?

Adds a simple check that is used elsewhere to check if localStorage *really* is able to be used
