### PR TITLE
feat: add a different synchronization approach

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
     "target": "ES2017",
 
     "strict": true,
+    "experimentalDecorators": true,
 
     "esModuleInterop": true,
     "moduleResolution": "Node",


### PR DESCRIPTION
Previously, the library attempted to synchronize access to the storage across browsers and tabs using a global lock initiated by the `_useSession` function. Because some recursive calls (i.e. `_useSession` called within `_useSession`) were likely, the concept of a stack guard was implemented to detect such calls. This prevented deadlocks with recursion. However, stack guards appear to be quite flaky depending on the environment in which the library runs (not supported in WebKit based platforms) or transpilation/compilation/minifaction toolchains.

This new approach removes the stack guard concept, and attempts to solve synchronization "externally" from the GoTrueClient. This is done like so:

- GoTrueClient no longer deals with acquiring the lock. All methods assume that when they're executing, they have been globally synchronized and there is no other competing client.
- The lock is acquired only when certain methods like `getSession`, `getUser` are called _from outside of the gotrue-js module._ It is implemented by exporting a wrapped `GoTrueClient` with a `Proxy` that detects those methods and acquires the lock before calling into them. These methods are annotated with `@synchronized`.
- Finally, initialization is also handled at the proxy level by acquiring the lock just before the constructed client is returned. The synchronized methods will wait for the initialization to finish before acquiring the lock and calling into the GoTrueClient code.