### PR TITLE
Update SignInWithIDToken docstring

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -519,8 +519,7 @@ export default class GoTrueClient {
   }
 
   /**
-   * Allows signing in with an OIDC ID token. The authentication provider used
-   * should be enabled and configured.
+   * Allows signing in with an OIDC ID token. The authentication provider used should be enabled and configured.
    */
   async signInWithIdToken(credentials: SignInWithIdTokenCredentials): Promise<AuthTokenResponse> {
     await this._removeSession()


### PR DESCRIPTION
Update tsdoc to be on one line for aesthetic purposes  when used in docs- currently split into two lines which looks slightly disjoint

<img width="438" alt="CleanShot 2023-08-14 at 12 09 48@2x" src="https://github.com/supabase/gotrue-js/assets/8011761/77fc7c65-af55-47b1-8ca4-939fd23fce1b">
