### PR TITLE
feat: acquire lock around visibility change callback

### DIFF
--- a/src/lib/locks.ts
+++ b/src/lib/locks.ts
@@ -1,4 +1,4 @@
-import { supportsLocalStorage } from "./helpers"
+import { supportsLocalStorage } from './helpers'
 
 /**
  * @experimental


### PR DESCRIPTION
Similarly to how the refresh token ticker needs to acquire the lock before checking whether the session needs to be refreshed, we need to do the same for the visibility change callback. This is difficult to spot because when one uses tabs instead of windows, there's often just one tab visible at once. But when using multiple windows, a window is not hidden when not focused, so events like waking from sleep will cause all windows to refresh the token at once. Adding the lock will serialize access, meaning that all windows will check the session, but only one will refresh.