### PR TITLE
feat: pkce challenge support in React Native with Segment

### DIFF
--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -289,7 +289,9 @@ function base64urlencode(str: string) {
 }
 
 export async function generatePKCEChallenge(verifier: string) {
-  if (typeof crypto === 'undefined') {
+  const hasCryptoSupport = typeof crypto !== 'undefined' && typeof crypto.subtle !== 'undefined' && typeof TextEncoder !== 'undefined';
+  
+  if (!hasCryptoSupport) {
     console.warn(
       'WebCrypto API is not supported. Code challenge method will default to use plain instead of sha256.'
     )


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR fixes an issue where gotrue would throw in React Native due to the lack of the crypto and TextEncoder module.

When [integrating Segment with React Native](https://segment.com/docs/connections/sources/catalog/libraries/mobile/react-native/), they ask you to install [react-native-get-random-values](https://github.com/LinusU/react-native-get-random-values) as a polyfill to crypto's `getRandomValue` method. This causes issues in gotrue, as the code does a simple `crypto !== undefined` check.

Since a lot of RN libraries polyfill only a subset of crypto's method, `crypto !== undefined` is not a bullet-proof way to check for support.

## What is the current behavior?

If you have Segment installed, and try to login with `supabase.auth.signInWithOtp` (email), the app throws an error.

## What is the new behavior?

If the required crypto modules are not available, it just fallbacks to plain text as the existing behavior instead of throwing an error.

