### PR TITLE
feat: allow customizing the debug log function

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -161,6 +161,7 @@ export default class GoTrueClient {
   protected broadcastChannel: BroadcastChannel | null = null
 
   protected logDebugMessages: boolean
+  protected logger: (message: string, ...args: any[]) => void = console.log
 
   /**
    * Create a new client for use in the browser.
@@ -176,7 +177,12 @@ export default class GoTrueClient {
     }
 
     const settings = { ...DEFAULT_OPTIONS, ...options }
-    this.logDebugMessages = settings.debug
+
+    this.logDebugMessages = !!settings.debug
+    if (typeof settings.debug === 'function') {
+      this.logger = settings.debug
+    }
+
     this.inMemorySession = null
     this.storageKey = settings.storageKey
     this.autoRefreshToken = settings.autoRefreshToken
@@ -234,7 +240,7 @@ export default class GoTrueClient {
 
   private _debug(...args: any[]): GoTrueClient {
     if (this.logDebugMessages) {
-      console.log(
+      this.logger(
         `GoTrueClient@${this.instanceID} (${version}) ${new Date().toISOString()}`,
         ...args
       )

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -70,8 +70,8 @@ export type GoTrueClientOptions = {
   fetch?: Fetch
   /* If set to 'pkce' PKCE flow. Defaults to the 'implicit' flow otherwise */
   flowType?: AuthFlowType
-  /* If debug messages are emitted. Can be used to inspect the behavior of the library. */
-  debug?: boolean
+  /* If debug messages are emitted. Can be used to inspect the behavior of the library. If set to a function, the provided function will be used instead of `console.log()` to perform the logging. */
+  debug?: boolean | ((message: string, ...args: any[]) => void)
   /**
    * Provide your own locking mechanism based on the environment. By default no locking is done at this time.
    *


### PR DESCRIPTION
Allows customizing the debug log function (which is `console.log` by default) to support complex logging scenarios such as writing the logs to IndexedDB or sending them to a server or other monitoring software. 