### PR TITLE
fix: support more than one digit of pagination metadata in `listUsers()`

### DIFF
--- a/src/GoTrueAdminApi.ts
+++ b/src/GoTrueAdminApi.ts
@@ -194,10 +194,14 @@ export default class GoTrueAdminApi {
       const total = response.headers.get('x-total-count') ?? 0
       const links = response.headers.get('link')?.split(',') ?? []
       if (links.length > 0) {
+        const regex = /page=(\d+)(?=&)[^>]*>; rel="(\w+)"/
         links.forEach((link: string) => {
-          const page = parseInt(link.split(';')[0].split('=')[1].substring(0, 1))
-          const rel = JSON.parse(link.split(';')[1].split('=')[1])
-          pagination[`${rel}Page`] = page
+          const match = regex.exec(link.trim())
+          if (match) {
+            const page = parseInt(match[1], 10)
+            const rel = match[2]
+            pagination[`${rel}Page`] = page
+          }
         })
 
         pagination.total = parseInt(total)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes an issue where the pagination metadata returned from `listUsers()` was inaccurate for page values `>= 10`.

## What is the current behavior?

The current behaviour assumes the `page` value contained in the link string (each element of which looks a bit like this: `</admin/users?page=7&per_page=10>; rel="last"`) is always a single digit, leading to truncated values for `nextPage` and `lastPage` being returned if either are 10 or more. For example, if `nextPage` is `10`, the current behaviour truncates this to `1`. If the client is relying on the value of `nextPage`, this could cause it to paginate up to page 9 correctly but then reset to page 1 rather than move on to page 10.

## What is the new behavior?

The new behaviour correctly parses multi-digit values for `nextPage` and `lastPage`.

## Additional context

I couldn't get the test suite running but didn't see any tests relating to this so I don't _think_ any tests will break. I patched the proposed changes into the project I have which was being tripped up by this behaviour and they appear to work as expected. Feel free to refactor - wasn't sure if changing the various `split()` calls to a regex was a no-no.

Thanks!
