### PR TITLE
fix: minor typo in warning message

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -1348,7 +1348,7 @@ export default class GoTrueClient {
         )
       } else if (timeNow - issuedAt < 0) {
         console.warn(
-          '@supabase/gotrue-js: Session as retrieved from URL was issued in the future? Check the device clok for skew',
+          '@supabase/gotrue-js: Session as retrieved from URL was issued in the future? Check the device clock for skew',
           issuedAt,
           expiresAt,
           timeNow


### PR DESCRIPTION
## What kind of change does this PR introduce?

I was digging through the code and found a minor typo in the warning message. Nothing too crazy.

## What is the current behavior?

N/A

## What is the new behavior?

N/A

## Additional context

N/A
