### PR TITLE
feat: default to `navigatorLock` on browsers

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -33,7 +33,7 @@ import {
 import { localStorageAdapter, memoryLocalStorageAdapter } from './lib/local-storage'
 import { polyfillGlobalThis } from './lib/polyfills'
 import { version } from './lib/version'
-import { LockAcquireTimeoutError } from './lib/locks'
+import { LockAcquireTimeoutError, navigatorLock } from './lib/locks'
 
 import type {
   AuthChangeEvent,
@@ -193,6 +193,14 @@ export default class GoTrueClient {
     this.lock = settings.lock || lockNoOp
     this.detectSessionInUrl = settings.detectSessionInUrl
     this.flowType = settings.flowType
+
+    if (settings.lock) {
+      this.lock = settings.lock
+    } else if (isBrowser() && globalThis?.navigator?.locks) {
+      this.lock = navigatorLock
+    } else {
+      this.lock = lockNoOp
+    }
 
     this.mfa = {
       verify: this._verify.bind(this),

--- a/src/lib/locks.ts
+++ b/src/lib/locks.ts
@@ -15,6 +15,11 @@ export const internals = {
   ),
 }
 
+/**
+ * An error thrown when a lock cannot be acquired after some amount of time.
+ *
+ * Use the {@link #isAcquireTimeout} property instead of checking with `instanceof`.
+ */
 export abstract class LockAcquireTimeoutError extends Error {
   public readonly isAcquireTimeout = true
 
@@ -42,8 +47,6 @@ export class NavigatorLockAcquireTimeoutError extends LockAcquireTimeoutError {}
  * lock releases a previously started promise to run the operation in the `fn`
  * function. The lock waits for that promise to finish (with or without error),
  * while the function will finally wait for the result anyway.
- *
- * @experimental
  *
  * @param name Name of the lock to be acquired.
  * @param acquireTimeout If negative, no timeout. If 0 an error is thrown if


### PR DESCRIPTION
After having spent months of real-world testing on supabase.com, the `navigatorLock` is enabled on browsers that support the [Navigator LocksManager API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Locks_API).

This makes sure that concurrent access to the storage in multiple tabs, windows or promises is no longer possible, thus removing issues such as:

- Refreshing the session in parallel
- Saving inconsistent state to storage
