### PR TITLE
email otp type - deprecated comment

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -592,6 +592,12 @@ export interface VerifyTokenHashParams {
 }
 
 export type MobileOtpType = 'sms' | 'phone_change'
+
+/**
+ * Represents the type of email OTP.
+ * @deprecated 'signup' and 'magiclink' are deprecated, use 'email' instead.
+ * @seee https://supabase.com/docs/reference/javascript/auth-verifyotp#auth-verifyotp
+ */
 export type EmailOtpType = 'signup' | 'invite' | 'magiclink' | 'recovery' | 'email_change' | 'email'
 
 export type ResendParams =


### PR DESCRIPTION
## What kind of change does this PR introduce?

just link to documentation and flag two options as deprecated

## What is the current behavior?

- https://github.com/supabase/gotrue/issues/905#issuecomment-1533128779
- https://github.com/supabase/supabase/issues/18680

## What is the new behavior?

Tell developer in his IDE about deprecated values and save a lot of time

## Additional context

Let's make this as standard please. Documentation in the code is the best.
