### PR TITLE
chore: add friendly name to enroll response

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -820,7 +820,7 @@ export type AuthMFAEnrollResponse =
            * to use it. Avoid loggin this value to the console. */
           uri: string
         }
-        /** Friendly Name of the Factor **/
+        /** Friendly name of the factor, useful for distinguishing between factors **/
         friendly_name: string
       }
       error: null

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -820,6 +820,8 @@ export type AuthMFAEnrollResponse =
            * to use it. Avoid loggin this value to the console. */
           uri: string
         }
+        /** Friendly Name of the Factor **/
+        friendly_name: string
       }
       error: null
     }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -821,7 +821,7 @@ export type AuthMFAEnrollResponse =
           uri: string
         }
         /** Friendly name of the factor, useful for distinguishing between factors **/
-        friendly_name: string
+        friendly_name?: string
       }
       error: null
     }


### PR DESCRIPTION
## What kind of change does this PR introduce?

We introduced friendly name in the response of `enroll` a while back: https://github.com/supabase/gotrue/pull/1277

This PR adds the field to the client library response