### PR TITLE
feat: add identity linking methods

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -286,6 +286,15 @@ export default class GoTrueClient {
         if (error) {
           this._debug('#_initialize()', 'error detecting session from URL', error)
 
+          // hacky workaround to keep the existing session if there's an error returned from identity linking
+          // TODO: once error codes are ready, we should match against it instead of the message
+          if (
+            error?.message === 'Identity is already linked' ||
+            error?.message === 'Identity is already linked to another user'
+          ) {
+            return { error }
+          }
+
           // failed login attempt via url,
           // remove old session as in verifyOtp, signUp and signInWith*
           await this._removeSession()

--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -5,7 +5,6 @@ import {
   AuthImplicitGrantRedirectError,
   AuthPKCEGrantCodeExchangeError,
   AuthInvalidCredentialsError,
-  AuthRetryableFetchError,
   AuthSessionMissingError,
   AuthInvalidTokenResponseError,
   AuthUnknownError,
@@ -1794,13 +1793,7 @@ export default class GoTrueClient {
   private async _saveSession(session: Session) {
     this._debug('#_saveSession()', session)
 
-    await this._persistSession(session)
-  }
-
-  private _persistSession(currentSession: Session) {
-    this._debug('#_persistSession()', currentSession)
-
-    return setItemAsync(this.storage, this.storageKey, currentSession)
+    await setItemAsync(this.storage, this.storageKey, session)
   }
 
   private async _removeSession() {

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -290,8 +290,11 @@ function base64urlencode(str: string) {
 }
 
 export async function generatePKCEChallenge(verifier: string) {
-  const hasCryptoSupport = typeof crypto !== 'undefined' && typeof crypto.subtle !== 'undefined' && typeof TextEncoder !== 'undefined';
-  
+  const hasCryptoSupport =
+    typeof crypto !== 'undefined' &&
+    typeof crypto.subtle !== 'undefined' &&
+    typeof TextEncoder !== 'undefined'
+
   if (!hasCryptoSupport) {
     console.warn(
       'WebCrypto API is not supported. Code challenge method will default to use plain instead of sha256.'

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -233,6 +233,7 @@ export interface UserIdentity {
   identity_data?: {
     [key: string]: any
   }
+  identity_id: string
   provider: string
   created_at?: string
   last_sign_in_at?: string


### PR DESCRIPTION
## What kind of change does this PR introduce?
* Adds 3 new methods: `unlinkIdentity`, `linkIdentity`, `getUserIdentities` to support the new identity linking endpoints
* All methods require the user to be authenticated 
* This PR should only be merged once the gotrue release with the new identity linking endpoints are deployed

## TODO
- [x] fix issue where user is logged out if linking fails