### PR TITLE
feat: base64-encode session value

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -993,7 +993,7 @@ export default class GoTrueClient {
     try {
       let currentSession: Session | null = null
 
-      const maybeSession = await getItemAsync(this.storage, this.storageKey)
+      const maybeSession = await getItemAsync(this.storage, this.storageKey, true)
 
       this._debug('#getSession()', 'session from storage', maybeSession)
 
@@ -1665,7 +1665,7 @@ export default class GoTrueClient {
     this._debug(debugName, 'begin')
 
     try {
-      const currentSession = await getItemAsync(this.storage, this.storageKey)
+      const currentSession = await getItemAsync(this.storage, this.storageKey, true)
       this._debug(debugName, 'session from storage', currentSession)
 
       if (!this._isValidSession(currentSession)) {
@@ -1820,7 +1820,8 @@ export default class GoTrueClient {
   private _persistSession(currentSession: Session) {
     this._debug('#_persistSession()', currentSession)
 
-    return setItemAsync(this.storage, this.storageKey, currentSession)
+    // encode the session in base64 for storages such as cookie
+    return setItemAsync(this.storage, this.storageKey, currentSession, true)
   }
 
   private async _removeSession() {

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -116,12 +116,18 @@ export const looksLikeFetchResponse = (maybeResponse: unknown): maybeResponse is
 export const setItemAsync = async (
   storage: SupportedStorage,
   key: string,
-  data: any
+  data: any,
+  base64 = false
 ): Promise<void> => {
-  await storage.setItem(key, JSON.stringify(data))
+  const value = JSON.stringify(data)
+  await storage.setItem(key, base64 ? encodeBase64URL(value) : value)
 }
 
-export const getItemAsync = async (storage: SupportedStorage, key: string): Promise<unknown> => {
+export const getItemAsync = async (
+  storage: SupportedStorage,
+  key: string,
+  base64 = false
+): Promise<unknown> => {
   const value = await storage.getItem(key)
 
   if (!value) {
@@ -129,7 +135,7 @@ export const getItemAsync = async (storage: SupportedStorage, key: string): Prom
   }
 
   try {
-    return JSON.parse(value)
+    return JSON.parse(base64 ? decodeBase64URL(value) : value)
   } catch {
     return value
   }
@@ -137,6 +143,12 @@ export const getItemAsync = async (storage: SupportedStorage, key: string): Prom
 
 export const removeItemAsync = async (storage: SupportedStorage, key: string): Promise<void> => {
   await storage.removeItem(key)
+}
+
+const encoder = new TextEncoder()
+
+export function encodeBase64URL(value: string): string {
+  return base64urlencode(Array.from(encoder.encode(value), (c) => String.fromCharCode(c)).join(''))
 }
 
 export function decodeBase64URL(value: string): string {

--- a/test/GoTrueClient.test.ts
+++ b/test/GoTrueClient.test.ts
@@ -1,3 +1,4 @@
+import { Buffer } from 'node:buffer'
 import { AuthError } from '../src/lib/errors'
 import {
   authClient as auth,
@@ -183,12 +184,15 @@ describe('GoTrueClient', () => {
       // @ts-expect-error 'Allow access to protected storageKey'
       const storageKey = authWithSession.storageKey
 
+      const value = Buffer.from(
+        (await storage.getItem(storageKey)) || Buffer.from('null').toString('base64url'),
+        'base64url'
+      ).toString('utf8')
       await storage.setItem(
         storageKey,
-        JSON.stringify({
-          ...JSON.parse((await storage.getItem(storageKey)) || 'null'),
-          expires_at: expiredSeconds,
-        })
+        Buffer.from(JSON.stringify({ ...JSON.parse(value), expires_at: expiredSeconds })).toString(
+          'base64url'
+        )
       )
 
       // wait 1 seconds before calling getSession()


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

The session cookie value is a plain JSON string, which gets encoded in ASCII-only storages, such as cookie store. Especially, this causes a mismatch in the length calculation in the cookie chunker in `@supabase/ssr`; sometimes, cookie values exceed the max length.

## What is the new behavior?

This PR base64-encodes the session value before saving in the storage.

The rationale for using base64:
- it is used in the JWT encoding
- URL encoding encodes `{`, `}`, `"`, `]` to 3 characters tripling in length, whereas base64 encoding increases `x4/3` in bytes, so the overall length would be similar

## Additional context

- Related
  - https://github.com/supabase/auth-helpers/issues/643
  - https://github.com/supabase/auth-helpers/issues/696
