### PR TITLE
feat: add `AuthWeakPasswordError`

### DIFF
--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -124,3 +124,25 @@ export class AuthRetryableFetchError extends CustomAuthError {
 export function isAuthRetryableFetchError(error: unknown): error is AuthRetryableFetchError {
   return isAuthError(error) && error.name === 'AuthRetryableFetchError'
 }
+
+/**
+ * This error is thrown on certain methods when the password used is deemed
+ * weak. Inspect the reasons to identify what password strength rules are
+ * inadequate.
+ */
+export class AuthWeakPasswordError extends CustomAuthError {
+  /**
+   * Reasons why the password is deemed weak.
+   */
+  reasons: ('length' | 'characters' | 'pwned' | string)[]
+
+  constructor(message: string, status: number, reasons: string[]) {
+    super(message, 'AuthWeakPasswordError', status)
+
+    this.reasons = reasons
+  }
+}
+
+export function isAuthWeakPasswordError(error: unknown): error is AuthWeakPasswordError {
+  return isAuthError(error) && error.name === 'AuthWeakPasswordError'
+}

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -290,8 +290,11 @@ function base64urlencode(str: string) {
 }
 
 export async function generatePKCEChallenge(verifier: string) {
-  const hasCryptoSupport = typeof crypto !== 'undefined' && typeof crypto.subtle !== 'undefined' && typeof TextEncoder !== 'undefined';
-  
+  const hasCryptoSupport =
+    typeof crypto !== 'undefined' &&
+    typeof crypto.subtle !== 'undefined' &&
+    typeof TextEncoder !== 'undefined'
+
   if (!hasCryptoSupport) {
     console.warn(
       'WebCrypto API is not supported. Code challenge method will default to use plain instead of sha256.'


### PR DESCRIPTION
Throws an `AuthWeakPasswordError` on non-200 JSON reponses that have the `weak_password` property as defined in:

- https://github.com/supabase/gotrue/blob/master/internal/api/password.go
- https://github.com/supabase/gotrue/blob/master/internal/api/errors.go#L244