### PR TITLE
rename: `gotrue` to `auth`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,8 +29,20 @@ jobs:
           npm ci
           npm run build
 
-      - name: Create a release
+      - name: Create a release for @supabase/auth-js
         run: npx semantic-release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create a release for @supabase/gotrue-js
+        run: |
+          for f in package.json package-lock.json
+          do
+            sed -i '' 's|\(["/]\)auth-js|\1gotrue-js|g' "$f"
+          done
+
+          npx semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,28 +1,28 @@
-# `gotrue-js`
+# `auth-js`
 
-An isomorphic JavaScript client library for the [GoTrue](https://github.com/supabase/gotrue) API.
+An isomorphic JavaScript client library for the [Supabase Auth](https://github.com/supabase/auth) API.
 
 ## Docs
 
-- Using `gotrue-js`: https://supabase.com/docs/reference/javascript/auth-signup
-- TypeDoc: https://supabase.github.io/gotrue-js/v2
+- Using `auth-js`: https://supabase.com/docs/reference/javascript/auth-signup
+- TypeDoc: https://supabase.github.io/auth-js/v2
 
 ## Quick start
 
 Install
 
 ```bash
-npm install --save @supabase/gotrue-js
+npm install --save @supabase/auth-js
 ```
 
 Usage
 
 ```js
-import { GoTrueClient } from '@supabase/gotrue-js'
+import { AuthClient } from '@supabase/auth-js'
 
 const GOTRUE_URL = 'http://localhost:9999'
 
-const auth = new GoTrueClient({ url: GOTRUE_URL })
+const auth = new AuthClient({ url: GOTRUE_URL })
 ```
 
 - `signUp()`: https://supabase.io/docs/reference/javascript/auth-signup
@@ -31,14 +31,14 @@ const auth = new GoTrueClient({ url: GOTRUE_URL })
 
 ### Custom `fetch` implementation
 
-`gotrue-js` uses the [`cross-fetch`](https://www.npmjs.com/package/cross-fetch) library to make HTTP requests, but an alternative `fetch` implementation can be provided as an option. This is most useful in environments where `cross-fetch` is not compatible, for instance Cloudflare Workers:
+`auth-js` uses the [`cross-fetch`](https://www.npmjs.com/package/cross-fetch) library to make HTTP requests, but an alternative `fetch` implementation can be provided as an option. This is most useful in environments where `cross-fetch` is not compatible, for instance Cloudflare Workers:
 
 ```js
-import { GoTrueClient } from '@supabase/gotrue-js'
+import { AuthClient } from '@supabase/auth-js'
 
-const GOTRUE_URL = 'http://localhost:9999'
+const AUTH_URL = 'http://localhost:9999'
 
-const auth = new GoTrueClient({ url: GOTRUE_URL, fetch: fetch })
+const auth = new AuthClient({ url: AUTH_URL, fetch: fetch })
 ```
 
 ## Sponsors

--- a/example/react/package-lock.json
+++ b/example/react/package-lock.json
@@ -8,7 +8,7 @@
       "name": "example",
       "version": "0.1.0",
       "dependencies": {
-        "@supabase/gotrue-js": "file:../..",
+        "@supabase/auth-js": "file:../..",
         "@testing-library/jest-dom": "^4.2.4",
         "@testing-library/react": "^9.5.0",
         "@testing-library/user-event": "^7.2.1",
@@ -19,7 +19,7 @@
       }
     },
     "../..": {
-      "name": "@supabase/gotrue-js",
+      "name": "@supabase/auth-js",
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
@@ -3049,7 +3049,7 @@
         "@sinonjs/commons": "^1.7.0"
       }
     },
-    "node_modules/@supabase/gotrue-js": {
+    "node_modules/@supabase/auth-js": {
       "resolved": "../..",
       "link": true
     },
@@ -19813,7 +19813,7 @@
         "@sinonjs/commons": "^1.7.0"
       }
     },
-    "@supabase/gotrue-js": {
+    "@supabase/auth-js": {
       "version": "file:../..",
       "requires": {
         "@supabase/node-fetch": "^2.6.14",

--- a/example/react/package.json
+++ b/example/react/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@supabase/gotrue-js": "file:../..",
+    "@supabase/auth-js": "file:../..",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.5.0",
     "@testing-library/user-event": "^7.2.1",

--- a/example/react/src/App.js
+++ b/example/react/src/App.js
@@ -1,11 +1,11 @@
 import React, { useEffect, useRef, useState } from 'react'
-import { GoTrueClient } from '@supabase/gotrue-js'
+import { AuthClient } from '@supabase/auth-js'
 import './tailwind.output.css'
 
 const supabaseURL = process.env.REACT_APP_SUPABASE_URL
 const supabaseAnon = process.env.REACT_APP_SUPABASE_ANON_KEY
 
-const auth = new GoTrueClient({
+const auth = new AuthClient({
   url: `${supabaseURL}/auth/v1`,
   headers: {
     accept: 'json',

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -2,7 +2,7 @@
 version: '3'
 services:
   gotrue: # Signup enabled, autoconfirm off
-    image: supabase/gotrue:latest
+    image: supabase/auth:v2.129.0
     ports:
       - '9999:9999'
     environment:
@@ -42,7 +42,7 @@ services:
       - db
     restart: on-failure
   autoconfirm: # Signup enabled, autoconfirm on
-    image: supabase/gotrue:latest
+    image: supabase/auth:v2.129.0
     ports:
       - '9998:9998'
     environment:
@@ -71,7 +71,7 @@ services:
       - db
     restart: on-failure
   disabled: # Signup disabled
-    image: supabase/gotrue:latest
+    image: supabase/auth:v2.129.0
     ports:
       - '9997:9997'
     environment:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@supabase/gotrue-js",
+  "name": "@supabase/auth-js",
   "version": "0.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@supabase/gotrue-js",
+      "name": "@supabase/auth-js",
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,15 +1,15 @@
 {
-  "name": "@supabase/gotrue-js",
+  "name": "@supabase/auth-js",
   "version": "0.0.0",
-  "description": "Isomorphic GoTrue client",
+  "description": "Official client library for Supabase Auth",
   "keywords": [
-    "gotrue",
+    "auth",
     "supabase",
     "auth",
     "authentication"
   ],
-  "homepage": "https://github.com/supabase/gotrue-js",
-  "bugs": "https://github.com/supabase/gotrue-js/issues",
+  "homepage": "https://github.com/supabase/auth-js",
+  "bugs": "https://github.com/supabase/auth-js/issues",
   "license": "MIT",
   "author": "Supabase",
   "files": [
@@ -19,7 +19,7 @@
   "main": "dist/main/index.js",
   "module": "dist/module/index.js",
   "types": "dist/module/index.d.ts",
-  "repository": "supabase/gotrue-js",
+  "repository": "supabase/auth-js",
   "scripts": {
     "clean": "rimraf dist docs",
     "coverage": "echo \"run npm test\"",

--- a/src/AuthAdminApi.ts
+++ b/src/AuthAdminApi.ts
@@ -1,0 +1,5 @@
+import GoTrueAdminApi from './GoTrueAdminApi'
+
+const AuthAdminApi = GoTrueAdminApi
+
+export default AuthAdminApi

--- a/src/AuthClient.ts
+++ b/src/AuthClient.ts
@@ -1,0 +1,5 @@
+import GoTrueClient from './GoTrueClient'
+
+const AuthClient = GoTrueClient
+
+export default AuthClient

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,8 @@
 import GoTrueAdminApi from './GoTrueAdminApi'
 import GoTrueClient from './GoTrueClient'
-export { GoTrueAdminApi, GoTrueClient }
+import AuthAdminApi from './AuthAdminApi'
+import AuthClient from './AuthClient'
+export { GoTrueAdminApi, GoTrueClient, AuthAdminApi, AuthClient }
 export * from './lib/types'
 export * from './lib/errors'
 export {

--- a/test/GoTrueApi.test.ts
+++ b/test/GoTrueApi.test.ts
@@ -384,7 +384,7 @@ describe('GoTrueAdminApi', () => {
       test('signOut() with an invalid access token', async () => {
         const { error } = await serviceRoleApiClient.signOut('this-is-a-bad-token')
 
-        expect(error?.message).toMatch(/^Invalid token/)
+        expect(error?.message).toMatch(/^invalid JWT/)
       })
     })
   })
@@ -420,7 +420,7 @@ describe('GoTrueAdminApi', () => {
         })
 
         expect(user).toBeNull()
-        expect(error?.message).toEqual('Invalid phone number format')
+        expect(error?.message).toEqual('Invalid phone number format (E.164 required)')
       })
     })
   })

--- a/test/GoTrueClient.test.ts
+++ b/test/GoTrueClient.test.ts
@@ -360,7 +360,7 @@ describe('GoTrueClient', () => {
       expect(data.session).toBeNull()
       expect(data.user).toBeNull()
 
-      expect(error?.message).toEqual('Error sending confirmation sms: Missing Twilio account SID')
+      expect(error?.message).toEqual('Error sending confirmation sms: missing Twilio account SID')
     })
 
     test('signUp() with phone', async () => {


### PR DESCRIPTION
Renames GoTrue to Auth.

`GoTrueClient` and `GoTrueAdminApi` still remain the main classes, but they're re-exported as `AuthClient` and `AuthAdminApi`.