### PR TITLE
ci: fix sed for releasing `@supabase/gotrue-js`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
         run: |
           for f in package.json package-lock.json
           do
-            sed -i '' 's|\(["/]\)auth-js|\1gotrue-js|g' "$f"
+            sed -i 's|\(["/]\)auth-js|\1gotrue-js|g' "$f"
           done
 
           npx semantic-release -r 'https://github.com/supabase/gotrue-js.git'


### PR DESCRIPTION
The stupid macOS incompatible `sed -i ''` option broke it.