### PR TITLE
fix: Type error on code exchange when no item in storage

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -515,9 +515,8 @@ export default class GoTrueClient {
       }
     | { data: { session: null; user: null; redirectType: null }; error: AuthError }
   > {
-    const [codeVerifier, redirectType] = (
-      (await getItemAsync(this.storage, `${this.storageKey}-code-verifier`)) as string
-    ).split('/')
+    const storageItem = await getItemAsync(this.storage, `${this.storageKey}-code-verifier`)
+    const [codeVerifier, redirectType] = ((storageItem ?? '') as string).split('/')
     const { data, error } = await _request(
       this.fetch,
       'POST',


### PR DESCRIPTION
## What kind of change does this PR introduce?

Currently when code exchange for pkce flow is triggered on device that didn't start the auth flow (e.g. signed up via magic link on laptop and clicked on the link on phone), `TypeError: Cannot read properties of null (reading 'split')` error is thrown. This PR fixes that.

Fixes the error pointed out here
https://github.com/supabase/gotrue-js/pull/813#discussion_r1428876014