### PR TITLE
package: set private to false

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@supabase/auth-js",
   "version": "0.0.0",
+  "private": false,
   "description": "Official client library for Supabase Auth",
   "keywords": [
     "auth",


### PR DESCRIPTION
Makes sure that `npm publish` runs in public mode always. https://stackoverflow.com/questions/41981686/getting-error-402-while-publishing-package-using-npm