### PR TITLE
fix: Emit password recovery event from verifyOtp when otp type is recovery

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -725,7 +725,10 @@ export default class GoTrueClient {
 
       if (session?.access_token) {
         await this._saveSession(session as Session)
-        await this._notifyAllSubscribers('SIGNED_IN', session)
+        await this._notifyAllSubscribers(
+          params.type == 'recovery' ? 'PASSWORD_RECOVERY' : 'SIGNED_IN',
+          session
+        )
       }
 
       return { data: { user, session }, error: null }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Currently when the user goes through the password recovery flow via OTP and calls the `verifyOtp()` method, the `SIGNED_IN` auth event is emitted instead of `PASSWORD_RECOVERY` event. 

## What is the new behavior?

When the user goes through the password recovery flow using email OTP, the `PASSWORD_RECOVERY` event is emitted. 

## Additional context

A Flutter SDK user reported this, and thought it probably makes sense to bring it to the JS client as well. https://github.com/supabase/supabase-flutter/pull/774