### PR TITLE
fix: upgrade to node 20

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node: ['18']
+        node: ['20']
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     name: Release / Node ${{ matrix.node }}
     strategy:
       matrix:
-        node: ['18']
+        node: ['20']
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

We move from node 18 to 20 mirroring changes across the org

It is also required for [the latest sem release which is used in the build](https://github.com/supabase/gotrue-js/actions/runs/7580380386/job/20646093342#step:5:10)