### PR TITLE
ci: add manual package publish on git tag

### DIFF
--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -1,0 +1,58 @@
+name: Manual Publish
+
+on:
+  workflow_dispatch:
+    inputs:
+      package:
+        description: Package name
+        type: choice
+        required: true
+        options:
+          - auth-js
+          - gotrue-js
+      version:
+        description: Version to publish (1.2.3 not v1.2.3)
+        type: string
+        required: true
+      reason:
+        description: Why are you manually publishing?
+        type: string
+        required: true
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - run: echo ${{ toJSON(inputs) }}
+
+      - uses: actions/checkout@v4
+        with:
+          ref: v${{ inputs.version }}
+
+      - name: Set up Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: '20'
+
+      - run: |
+          npm ci
+          npm run build
+
+      - name: Publish @supabase/${{ input.package }} @v${{ input.version }}
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' > ~/.npmrc
+
+          set -ex
+
+          for f in package.json package-lock.json
+          do
+            sed -i 's/0.0.0/${{ inputs.version }}/' "$f"
+
+            sed -i 's|\(["/]\)auth-js|\1${{ inputs.package }}|g' "$f"
+          done
+
+          npm publish # not with --tag latest!
+


### PR DESCRIPTION
Adds an option to manually publish a tag on NPM in case the release CI job has bugs or has failed to publish the correct artifact on NPM.