### PR TITLE
feat: warn use of `getSession()` when `isServer` on storage

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1079,7 +1079,18 @@ type PromisifyMethods<T> = {
     : T[K]
 }
 
-export type SupportedStorage = PromisifyMethods<Pick<Storage, 'getItem' | 'setItem' | 'removeItem'>>
+export type SupportedStorage = PromisifyMethods<
+  Pick<Storage, 'getItem' | 'setItem' | 'removeItem'>
+> & {
+  /**
+   * If set to `true` signals to the library that the storage medium is used
+   * on a server and the values may not be authentic, such as reading from
+   * request cookies. Implementations should not set this to true if the client
+   * is used on a server that reads storage information from authenticated
+   * sources, such as a secure database or file.
+   */
+  isServer?: boolean
+}
 
 export type InitializeResult = { error: AuthError | null }
 


### PR DESCRIPTION
Warn about using `getSession()` when the storage has `isSever` to true without previously having called `getUser()`.

Warn each time the `user` is accessed as returned by `getSession()`.

Relates to:
- https://github.com/supabase/auth-helpers/pull/722