### PR TITLE
feat: explicit `cache: no-store` in fetch

### DIFF
--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -118,7 +118,10 @@ export async function _request(
     fetcher,
     method,
     url + queryString,
-    { headers, noResolveJson: options?.noResolveJson },
+    {
+      headers,
+      noResolveJson: options?.noResolveJson,
+    },
     {},
     options?.body
   )
@@ -138,7 +141,12 @@ async function _handleRequest(
   let result: any
 
   try {
-    result = await fetcher(url, requestParams)
+    result = await fetcher(url, {
+      ...requestParams,
+      // UNDER NO CIRCUMSTANCE SHOULD THIS OPTION BE REMOVED, YOU MAY BE OPENING UP A SECURITY HOLE IN NEXT.JS APPS
+      // https://nextjs.org/docs/app/building-your-application/caching#opting-out-1
+      cache: 'no-store',
+    })
   } catch (e) {
     console.error(e)
 


### PR DESCRIPTION
Next.js polyfills the `fetch` on the server side to always cache (what's known as their Data Cache) responses. Quote:

> Next.js has a built-in Data Cache that persists the result of data fetches across incoming server requests and deployments. This is possible because Next.js extends the native fetch API to allow each request on the server to set its own persistent caching semantics.
>
>  Good to know: In the browser, the cache option of fetch indicates how a request will interact with the browser's HTTP cache, in Next.js, the cache option indicates how a server-side request will interact with the server's Data Cache.

This is _incredibly dangerous_ for Auth use cases. Thankfully, it appears that using the default client uses `@supabase/node-fetch` in such a circumstance which should not be affected by the issue.

However, if developers do choose to switch back to the native `fetch` in Next.js the library must inform that HTTP client that there should be no caching under any circumstance on Auth responses.

Opting out docs: https://nextjs.org/docs/app/building-your-application/caching#opting-out-1