### PR TITLE
ci: add conventional commits linter

### DIFF
--- a/.github/workflows/conventional-commits-lint.js
+++ b/.github/workflows/conventional-commits-lint.js
@@ -1,0 +1,101 @@
+"use strict";
+
+const fs = require("fs");
+
+const TITLE_PATTERN =
+  /^(?<prefix>[^:!(]+)(?<package>\([^)]+\))?(?<breaking>[!])?:.+$/;
+const RELEASE_AS_DIRECTIVE = /^\s*Release-As:/im;
+const BREAKING_CHANGE_DIRECTIVE = /^\s*BREAKING[ \t]+CHANGE:/im;
+
+const ALLOWED_CONVENTIONAL_COMMIT_PREFIXES = [
+  "feat",
+  "fix",
+  "ci",
+  "docs",
+  "chore",
+];
+
+const object = process.argv[2];
+const payload = JSON.parse(fs.readFileSync(process.stdin.fd, "utf-8"));
+
+let validate = [];
+
+if (object === "pr") {
+  validate.push({
+    title: payload.pull_request.title,
+    content: payload.pull_request.body,
+  });
+} else if (object === "push") {
+  validate.push(
+    ...payload.commits.map((commit) => ({
+      title: commit.message.split("\n")[0],
+      content: commit.message,
+    })),
+  );
+} else {
+  console.error(
+    `Unknown object for first argument "${object}", use 'pr' or 'push'.`,
+  );
+  process.exit(0);
+}
+
+let failed = false;
+
+validate.forEach((payload) => {
+  if (payload.title) {
+    const { groups } = payload.title.match(TITLE_PATTERN);
+
+    if (groups) {
+      if (groups.breaking) {
+        console.error(
+          `PRs are not allowed to declare breaking changes at this stage of the project. Please remove the ! in your PR title or commit message and adjust the functionality to be backward compatible.`,
+        );
+        failed = true;
+      }
+
+      if (
+        !ALLOWED_CONVENTIONAL_COMMIT_PREFIXES.find(
+          (prefix) => prefix === groups.prefix,
+        )
+      ) {
+        console.error(
+          `PR (or a commit in it) is using a disallowed conventional commit prefix ("${groups.prefix}"). Only ${ALLOWED_CONVENTIONAL_COMMIT_PREFIXES.join(", ")} are allowed. Make sure the prefix is lowercase!`,
+        );
+        failed = true;
+      }
+
+      if (groups.package && groups.prefix !== "chore") {
+        console.warn(
+          "Avoid using package specifications in PR titles or commits except for the `chore` prefix.",
+        );
+      }
+    } else {
+      console.error(
+        "PR or commit title must match conventional commit structure.",
+      );
+      failed = true;
+    }
+  }
+
+  if (payload.content) {
+    if (payload.content.match(RELEASE_AS_DIRECTIVE)) {
+      console.error(
+        "PR descriptions or commit messages must not contain Release-As conventional commit directives.",
+      );
+      failed = true;
+    }
+
+    if (payload.content.match(BREAKING_CHANGE_DIRECTIVE)) {
+      console.error(
+        "PR descriptions or commit messages must not contain a BREAKING CHANGE conventional commit directive. Please adjust the functionality to be backward compatible.",
+      );
+      failed = true;
+    }
+  }
+});
+
+if (failed) {
+  process.exit(1);
+}
+
+process.exit(0);

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -1,0 +1,43 @@
+name: Check pull requests
+
+on:
+  push:
+    branches-ignore: # Run the checks on all branches but the protected ones
+      - master
+      - release/*
+
+  pull_request_target:
+    branches:
+      - master
+      - release/*
+    types:
+      - opened
+      - edited
+      - reopened
+      - ready_for_review
+
+jobs:
+  check-conventional-commits:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            .github
+
+      - if: ${{ github.event_name == 'pull_request_target' }}
+        run: |
+          set -ex
+
+          node .github/workflows/conventional-commits-lint.js pr <<EOF
+          ${{ toJSON(github.event) }}
+          EOF
+
+      - if: ${{ github.event_name == 'push' }}
+        run: |
+          set -ex
+
+          node .github/workflows/conventional-commits-lint.js push <<EOF
+          ${{ toJSON(github.event) }}
+          EOF


### PR DESCRIPTION
Adds a linter for commits and PRs to ensure that correct structure is observed. Certain directives are not compatible with this project:

- Breaking changes are not allowed. Therefore PR titles or commit messages must not use the `!` nor the `BREAKING CHANGE` directive in descriptions or commit messages.
- The `Release-As` directive is not supported as it can break the release process.
- For cleanliness, only a few conventional commit prefixes are allowed.

These are linted using a simple JavaScript script that runs on PRs and pushes.

Similar to:
- https://github.com/supabase/gotrue/pull/1392