### PR TITLE
feat: add method for anonymous sign-in

### DIFF
--- a/example/react/package.json
+++ b/example/react/package.json
@@ -12,6 +12,9 @@
     "react-scripts": "5.0.1",
     "tailwindcss": "^1.8.10"
   },
+  "devDependencies": {
+    "@babel/plugin-proposal-private-property-in-object": "^7.21.11"
+  },
   "scripts": {
     "build:tailwind": "tailwindcss build src/App.css -o src/tailwind.output.css",
     "prestart": "npm run build:tailwind",

--- a/example/react/src/App.js
+++ b/example/react/src/App.js
@@ -41,13 +41,11 @@ function App() {
       console.log(event, session)
       if (event === 'SIGNED_OUT' || event === 'SIGNED_IN') {
         setSession(session)
-        window.location.reload()
       }
     })
 
     return () => {
-      if (subscription) {
-        console.log('Subscription: ', subscription)
+      if (subscription.subscription) {
         subscription.unsubscribe()
       }
     }
@@ -93,6 +91,10 @@ function App() {
   async function handleSignOut() {
     let { error } = await auth.signOut()
     if (error) console.log('Error: ', error)
+  }
+  async function handleSignInAnonymously(data) {
+    let { error } = await auth.signInAnonymously({ options: { data } })
+    if (error) alert(error.message)
   }
   async function forgotPassword() {
     var email = prompt('Please enter your email:')
@@ -390,6 +392,17 @@ function App() {
                     className="w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-500 focus:outline-none focus:border-indigo-700 focus:shadow-outline-indigo active:bg-indigo-700 transition duration-150 ease-in-out"
                   >
                     Google
+                  </button>
+                </span>
+              </div>
+              <div className="mt-6">
+                <span className="block w-full rounded-md shadow-sm">
+                  <button
+                    onClick={() => handleSignInAnonymously({ color: 'blue' })}
+                    type="button"
+                    className="w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-500 focus:outline-none focus:border-indigo-700 focus:shadow-outline-indigo active:bg-indigo-700 transition duration-150 ease-in-out"
+                  >
+                    Sign In Anonymously
                   </button>
                 </span>
               </div>

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -452,6 +452,13 @@ export interface UpdatableFactorAttributes {
   friendlyName: string
 }
 
+export type SignInAnonymouslyCredentials = {
+  options?: {
+    data?: object
+    captchaToken?: string
+  }
+}
+
 export type SignUpWithPasswordCredentials =
   | {
       /** The user's email address. */

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -366,7 +366,7 @@ export interface UserAttributes {
   nonce?: string
 
   /**
-   * A custom data object to store the user's metadata. This maps to the `auth.users.user_metadata` column.
+   * A custom data object to store the user's metadata. This maps to the `auth.users.raw_user_meta_data` column.
    *
    * The `data` should be a JSON object that includes user-specific info, such as their first and last name.
    *
@@ -376,7 +376,7 @@ export interface UserAttributes {
 
 export interface AdminUserAttributes extends Omit<UserAttributes, 'data'> {
   /**
-   * A custom data object to store the user's metadata. This maps to the `auth.users.user_metadata` column.
+   * A custom data object to store the user's metadata. This maps to the `auth.users.raw_user_meta_data` column.
    *
    *
    * The `user_metadata` should be a JSON object that includes user-specific info, such as their first and last name.
@@ -454,7 +454,13 @@ export interface UpdatableFactorAttributes {
 
 export type SignInAnonymouslyCredentials = {
   options?: {
+    /**
+     * A custom data object to store the user's metadata. This maps to the `auth.users.raw_user_meta_data` column.
+     *
+     * The `data` should be a JSON object that includes user-specific info, such as their first and last name.
+     */
     data?: object
+    /** Verification token received when the user completes the captcha on the site. */
     captchaToken?: string
   }
 }
@@ -469,7 +475,7 @@ export type SignUpWithPasswordCredentials =
         /** The redirect url embedded in the email link */
         emailRedirectTo?: string
         /**
-         * A custom data object to store the user's metadata. This maps to the `auth.users.user_metadata` column.
+         * A custom data object to store the user's metadata. This maps to the `auth.users.raw_user_meta_data` column.
          *
          * The `data` should be a JSON object that includes user-specific info, such as their first and last name.
          */
@@ -485,7 +491,7 @@ export type SignUpWithPasswordCredentials =
       password: string
       options?: {
         /**
-         * A custom data object to store the user's metadata. This maps to the `auth.users.user_metadata` column.
+         * A custom data object to store the user's metadata. This maps to the `auth.users.raw_user_meta_data` column.
          *
          * The `data` should be a JSON object that includes user-specific info, such as their first and last name.
          */
@@ -528,7 +534,7 @@ export type SignInWithPasswordlessCredentials =
         /** If set to false, this method will not create a new user. Defaults to true. */
         shouldCreateUser?: boolean
         /**
-         * A custom data object to store the user's metadata. This maps to the `auth.users.user_metadata` column.
+         * A custom data object to store the user's metadata. This maps to the `auth.users.raw_user_meta_data` column.
          *
          * The `data` should be a JSON object that includes user-specific info, such as their first and last name.
          */
@@ -544,7 +550,7 @@ export type SignInWithPasswordlessCredentials =
         /** If set to false, this method will not create a new user. Defaults to true. */
         shouldCreateUser?: boolean
         /**
-         * A custom data object to store the user's metadata. This maps to the `auth.users.user_metadata` column.
+         * A custom data object to store the user's metadata. This maps to the `auth.users.raw_user_meta_data` column.
          *
          * The `data` should be a JSON object that includes user-specific info, such as their first and last name.
          */
@@ -715,7 +721,7 @@ export type GenerateEmailChangeLinkParams = {
 
 export interface GenerateLinkOptions {
   /**
-   * A custom data object to store the user's metadata. This maps to the `auth.users.user_metadata` column.
+   * A custom data object to store the user's metadata. This maps to the `auth.users.raw_user_meta_data` column.
    *
    * The `data` should be a JSON object that includes user-specific info, such as their first and last name.
    */


### PR DESCRIPTION
## What kind of change does this PR introduce?
* https://github.com/supabase/gotrue/issues/68
* Adds the `signInAnonymously` method to support https://github.com/supabase/gotrue/pull/1460
* Passing in user metadata / the captcha token in `signInAnonymously` looks like: 
    `signInAnonymously({ options: { data, captchaToken }})` 
which follows the same format as the other sign up / sign in methods
