### PR TITLE
feat(getSession): option to suppress server side getSession warning manually

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -912,9 +912,11 @@ export default class GoTrueClient {
    * to the client. If that storage is based on request cookies for example,
    * the values in it may not be authentic and therefore it's strongly advised
    * against using this method and its results in such circumstances. A warning
-   * will be emitted if this is detected. Use {@link #getUser()} instead.
+   * will be emitted if this is detected, unless suppressWarning is set to true. Use {@link #getUser()} instead.
    */
-  async getSession() {
+  async getSession(options: {suppressWarning?: boolean} = {}) {
+    this.suppressGetSessionWarning = options?.suppressWarning ?? false
+
     await this.initializePromise
 
     const result = await this._acquireLock(-1, async () => {


### PR DESCRIPTION
## What kind of change does this PR introduce?
options param introduced on `getSession` with a `suppressWarning` prop to suppress the following server warning:

> Using the user object as returned from supabase.auth.getSession() or from some supabase.auth.onAuthStateChange() events could be insecure! This value comes directly from the storage medium (usually cookies on the server) and many not be authentic. Use supabase.auth.getUser() instead which authenticates the data by contacting the Supabase Auth server.

## What is the current behavior?
Currently the warning is displayed whenever getSession is accessed from the server, this causes excessive logs and hurts DX.

https://github.com/supabase/auth-js/issues/873
https://github.com/supabase/auth-js/pull/895

## What is the new behavior?
Warnings are suppress if `suppressWarning: true` in `options`




## Additional context

Add any other context or screenshots.
