### PR TITLE
fix: avoid `window.location` access in SSR environments

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -2144,7 +2144,7 @@ export default class GoTrueClient {
       maybeSession !== null &&
       'access_token' in maybeSession &&
       'refresh_token' in maybeSession &&
-      'expires_at' in maybeSession
+      'expires_in' in maybeSession
 
     return isValidSession
   }


### PR DESCRIPTION
When creating a Supabase client on the server side, the _initialize() method tries to access window.location.href, causing a ReferenceError and crashing the process. As a result, the method this.recoverAndRefresh responsible for restoring and refreshing the authentication state does not get called properly. other methods may recover the session later, so this doesn’t immediately break all functionality. However, this still represents an inconsistent design: recoverAndRefresh() is server-compatible, yet it's gated behind a browser-only execution path. 

## What is the new behavior?

This change adds a check using isBrowser() to avoid accessing window.location.href on the server side by providing empty parameters instead. This prevents the crash and allows this.recoverAndRefresh to be called correctly, enabling proper restoration and refreshing of the authentication state in server-side environments.
## Additional context

Closes supabase/supabase-js#1617
