### PR TITLE
feat: add suppressGetSessionWarning option to suppress server-side wa…

### DIFF
--- a/src/GoTrueClient.ts
+++ b/src/GoTrueClient.ts
@@ -128,6 +128,7 @@ const DEFAULT_OPTIONS: Omit<
   flowType: 'implicit',
   debug: false,
   hasCustomAuthorizationHeader: false,
+  suppressGetSessionWarning: false,
 }
 
 async function lockNoOp<R>(name: string, acquireTimeout: number, fn: () => Promise<R>): Promise<R> {
@@ -234,6 +235,7 @@ export default class GoTrueClient {
     this.detectSessionInUrl = settings.detectSessionInUrl
     this.flowType = settings.flowType
     this.hasCustomAuthorizationHeader = settings.hasCustomAuthorizationHeader
+    this.suppressGetSessionWarning = settings.suppressGetSessionWarning
 
     if (settings.lock) {
       this.lock = settings.lock

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -95,6 +95,11 @@ export type GoTrueClientOptions = {
    * @experimental
    */
   hasCustomAuthorizationHeader?: boolean
+  /**
+   * Set to "true" if you want to suppress the warning when getting a session in server side environments.
+   * @experimental
+   */
+  suppressGetSessionWarning?: boolean
 }
 
 export type WeakPasswordReasons = 'length' | 'characters' | 'pwned' | (string & {})

--- a/test/GoTrueClient.test.ts
+++ b/test/GoTrueClient.test.ts
@@ -1694,6 +1694,35 @@ describe('GoTrueClient with storageisServer = true', () => {
     expect(warnings.length).toEqual(0)
   })
 
+  test('getSession emits no warnings when suppressGetSessionWarning is set to true', async () => {
+    const storage = memoryLocalStorageAdapter({
+      [STORAGE_KEY]: JSON.stringify({
+        access_token: 'jwt.accesstoken.signature',
+        refresh_token: 'refresh-token',
+        token_type: 'bearer',
+        expires_in: 1000,
+        expires_at: Date.now() / 1000 + 1000,
+        user: {
+          id: 'random-user-id',
+        },
+      }),
+    })
+    storage.isServer = true
+
+    const client = new GoTrueClient({
+      storage,
+      suppressGetSessionWarning: true,
+    })
+
+    const {
+      data: { session },
+    } = await client.getSession()
+
+    const user = session?.user // accessing the user object from getSession shouldn't emit a warning
+    expect(user).not.toBeNull()
+    expect(warnings.length).toEqual(0)
+  })
+
   test('saveSession should overwrite the existing session', async () => {
     const store = memoryLocalStorageAdapter()
     const client = new GoTrueClient({


### PR DESCRIPTION
## What kind of change does this PR introduce?
Add option to suppress `getSession` warning in GoTrue client

## What is the current behavior?
When `getSession` is called on the server-side, it always triggers a warning. Many users find this disruptive. Although a flag exists to suppress the warning, it only applies from the second call onward, and currently there is no way to disable it by default.

## What is the new behavior?
Adds a flag to override `suppressGetSessionWarning` in the constructor, allowing users to choose whether to enable it when instantiating the client. Added tests as well.

## Additional context
Closes supabase/supabase-js#1597

See also supabase/auth-js#953
There is a related pull request currently open. I felt it might be clearer to offer this option at the time of client instantiation rather than when calling the method, so I have submitted a new pull request.
